### PR TITLE
Succinct crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stm32l4xx-hal"
+name = "stm32l4-hal"
 version = "0.3.0"
 authors = ["Scott Mabin <MabezDev@gmail.com>"]
 description = "Hardware abstraction layer for the stm32l4xx chips"


### PR DESCRIPTION
I kind of feel strongly about `stm32l4-hal` being the better crate name than `stm32l4xx-hal` :)