### PR TITLE
As slice dma - Last nighlty feature gate removed

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,11 +1,33 @@
-[target.thumbv7em-none-eabi]
-runner = 'arm-none-eabi-gdb'
+#[target.thumbv7m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+# runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+
 rustflags = [
+  # LLD (shipped with the Rust toolchain) is used as the default linker
   "-C", "link-arg=-Tlink.x",
-  "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
-  # "-Z", "thinlto=no",
+
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  # "-C", "linker=arm-none-eabi-ld",
+
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
 ]
 
 [build]
-target = "thumbv7em-none-eabi"
+# Pick ONE of these compilation targets
+# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
+# target = "thumbv7m-none-eabi"    # Cortex-M3
+target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+# target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ edition = "2018"
 cortex-m = "0.5.8"
 nb = "0.1.1"
 stm32l4 = "0.4.0"
+as-slice = "0.1"
 
 [dependencies.cast]
 version  = "0.2.2"
@@ -32,6 +33,10 @@ default-features = false
 [dependencies.void]
 version = "1.0.2"
 default-features = false
+
+[dependencies.stable_deref_trait]
+default-features = false
+version = "1.1"
 
 [dependencies.embedded-hal]
 version = "0.2.2"

--- a/examples/serial_dma_us2.rs
+++ b/examples/serial_dma_us2.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
 
     // TRY using a different USART peripheral here
-    let serial = Serial::usart2(p.USART2, (tx, rx), 9_600.bps(), clocks, &mut rcc.apb1r1);
+    let serial = Serial::usart2(p.USART2, (tx, rx), 115200.bps(), clocks, &mut rcc.apb1r1);
     let (mut tx, rx) = serial.split();
 
     let sent = b'X';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@
 
 #![no_std]
 
-// TODO, remove this feature (currently required in dma.rs)
-#![feature(unsize)]
 
 pub use embedded_hal as hal;
 


### PR DESCRIPTION
Moved to a as-slice buffer system for the DMA. This crate now compiles on rust 1.31 stable!