### PR TITLE
change i2c import to not be hardcoded

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,7 +1,7 @@
 //! Inter-Integrated Circuit (I2C) bus
 
 use cast::u8;
-use stm32l4::stm32l4x2::{I2C1, I2C2};
+use crate::stm32::{I2C1, I2C2};
 
 use crate::gpio::gpioa::{PA10, PA9};
 use crate::gpio::gpiob::{PB6, PB7};


### PR DESCRIPTION
I was trying to use this crate with a STM32L476, but wouldn't compile since this crate import was hardcoded to the STM32L4x2.
I did not test this but don't see why it wouldn't work!