### PR TITLE
RNG implementation and related

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,10 @@ stm32l4x2 = ["stm32l4/stm32l4x2"]
 stm32l4x3 = ["stm32l4/stm32l4x3"]
 stm32l4x5 = ["stm32l4/stm32l4x5"]
 stm32l4x6 = ["stm32l4/stm32l4x6"]
+unproven = ["embedded-hal/unproven"]
 
 [dev-dependencies]
+panic-halt = "0.2.0"
 panic-semihosting = "0.5.0"
 cortex-m-semihosting = "0.3.1"
 cortex-m-rt = "0.6.6"

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -1,0 +1,81 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use core::fmt;
+use cortex_m_rt::entry;
+
+use stm32l4xx_hal as hal;
+use crate::hal::stm32;
+use crate::hal::prelude::*;
+use crate::hal::delay::Delay;
+use crate::hal::serial::Serial;
+
+macro_rules! uprint {
+    ($serial:expr, $($arg:tt)*) => {
+        fmt::write($serial, format_args!($($arg)*)).ok()
+    };
+}
+
+macro_rules! uprintln {
+    ($serial:expr, $fmt:expr) => {
+        uprint!($serial, concat!($fmt, "\n"))
+    };
+    ($serial:expr, $fmt:expr, $($arg:tt)*) => {
+        uprint!($serial, concat!($fmt, "\n"), $($arg)*)
+    };
+}
+
+#[entry]
+fn main() -> ! {
+
+    let core = cortex_m::Peripherals::take().unwrap();
+    let device = stm32::Peripherals::take().unwrap();
+
+    let mut flash = device.FLASH.constrain();
+    let mut rcc = device.RCC.constrain();
+
+    let clocks = rcc.cfgr
+        .hsi48(true)  // needed for RNG
+        .sysclk(64.mhz()).pclk1(32.mhz())
+        .freeze(&mut flash.acr);
+
+    // setup usart
+    let mut gpioa = device.GPIOA.split(&mut rcc.ahb2);
+    let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
+    let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
+
+    let baud_rate = 9_600;  // 115_200;
+    let serial = Serial::usart1(
+        device.USART1,
+        (tx, rx),
+        baud_rate.bps(),
+        clocks,
+        &mut rcc.apb2
+    );
+    let (mut tx, _) = serial.split();
+
+    // get a timer
+    let mut timer = Delay::new(core.SYST, clocks);
+
+    // setup rng
+    let mut rng = device.RNG.enable(&mut rcc.ahb2, clocks);
+
+    uprintln!(&mut tx, "{:?}", clocks);
+
+    let some_time: u32 = 500;
+    loop {
+        const N: usize = 5;
+        let mut random_bytes = [0u8; N];
+        rng.read(&mut random_bytes).expect("missing random data for some reason");
+        uprintln!(
+            &mut tx,
+            "{} random u8 values: {:?}",
+            N, random_bytes
+        );
+
+        timer.delay_ms(some_time);
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,4 +71,5 @@ pub mod datetime;
 pub mod tsc;
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x2", feature = "stm32l4x3", feature = "stm32l4x5", feature = "stm32l4x6"))]
 pub mod i2c;
-
+#[cfg(any(feature = "stm32l4x2"))]
+pub mod rng;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,3 +9,4 @@ pub use crate::time::U32Ext as _stm32l4_hal_time_U32Ext;
 pub use crate::datetime::U32Ext as _stm32l4_hal_datetime_U32Ext;
 pub use crate::dma::DmaExt as _stm32l4_hal_DmaExt;
 pub use crate::pwr::PwrExt as _stm32l4_hal_PwrExt;
+pub use crate::rng::RngExt as _stm32l4_hal_RngExt;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -29,7 +29,7 @@ impl RccExt for RCC {
             cfgr: CFGR {
                 hclk: None,
                 hsi48: false,
-                lsi: true,
+                lsi: false,
                 pclk1: None,
                 pclk2: None,
                 sysclk: None,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,123 @@
+extern crate core;
+#[cfg(feature = "unproven")]
+use core::cmp;
+#[cfg(feature = "unproven")]
+use core::mem::transmute;
+
+use crate::rcc::{AHB2, Clocks};
+use crate::stm32::RNG;
+
+/// Extension trait to activate the RNG
+pub trait RngExt {
+    /// Enables the RNG
+    fn enable(self, ahb2: &mut AHB2, clocks: Clocks) -> Rng;
+}
+
+impl RngExt for RNG {
+
+    fn enable(self, ahb2: &mut AHB2, clocks: Clocks) -> Rng {
+        // crrcr.crrcr().modify(|_, w| w.hsi48on().set_bit()); // p. 180 in ref-manual
+        // ...this is now supposed to be done in RCC configuration before freezing
+
+        // hsi48 should be turned on previously
+        // TODO: should we return a Result instead of asserting here?
+        assert!(clocks.hsi48());
+
+        ahb2.enr().modify(|_, w| w.rngen().set_bit());
+        // if we don't do this... we can be "too fast", and
+        // the following setting of rng.cr.rngen has no effect!!
+        while ahb2.enr().read().rngen().bit_is_clear() {}
+
+        self.cr.modify(|_, w| w.rngen().set_bit());
+
+        Rng {
+            rng: self
+        }
+    }
+}
+
+/// Constrained RNG peripheral
+pub struct Rng {
+    rng: RNG,
+}
+
+impl Rng {
+
+    // cf. https://github.com/nrf-rs/nrf51-hal/blob/master/src/rng.rs#L31
+    pub fn free(self) -> RNG {
+        // maybe disable the RNG?
+        self.rng
+    }
+
+    // various methods that are not in the blessed embedded_hal
+    // trait list, but may be helpful nonetheless
+    // Q: should these be prefixed by underscores?
+
+    pub fn get_random_data(&self)-> u32 {
+        while !self.is_data_ready() {}
+        let word = self.possibly_invalid_random_data();
+        // NB: no need to clear bit here
+        word
+    }
+
+    // RNG_CR
+    /* missing in stm32l4...
+    pub fn is_clock_error_detection_enabled(&self) -> bool {
+        self.rng.cr.read().ced().bit()
+    }
+    */
+
+    pub fn is_interrupt_enabled(&self) -> bool {
+        self.rng.cr.read().ie().bit()
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.rng.cr.read().rngen().bit()
+    }
+
+    // RNG_SR
+    pub fn is_clock_error(&self) -> bool {
+        self.rng.sr.read().cecs().bit()
+    }
+
+    pub fn is_seed_error(&self) -> bool {
+        self.rng.sr.read().secs().bit()
+    }
+
+    pub fn is_data_ready(&self) -> bool {
+        self.rng.sr.read().drdy().bit()
+    }
+
+    // RNG_DR
+    pub fn possibly_invalid_random_data(&self) -> u32 {
+        self.rng.dr.read().rndata().bits()
+    }
+
+}
+
+#[derive(Debug)]
+pub enum Error {}
+
+#[cfg(feature = "unproven")]
+impl crate::hal::blocking::rng::Read for Rng {
+
+    // TODO: this error seems pretty useless if it
+    // doesn't flag non-enabled RNG or non-started HSI48,
+    // but that would be a runtime cost :/
+    type Error = Error;
+
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+
+        let mut i = 0usize;
+        while i < buffer.len() {
+            let random_word: u32 = self.get_random_data();
+            let bytes = unsafe { transmute::<u32, [u8; 4]>(random_word) };
+            let n = cmp::min(4, buffer.len() - i);
+            buffer[i..i + n].copy_from_slice(&bytes[..n]);
+            i += n;
+        }
+
+        Ok(())
+
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,19 +5,19 @@ use cortex_m::peripheral::DWT;
 use crate::rcc::Clocks;
 
 /// Bits per second
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bps(pub u32);
 
 /// Hertz
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Hertz(pub u32);
 
 /// KiloHertz
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct KiloHertz(pub u32);
 
 /// MegaHertz
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct MegaHertz(pub u32);
 
 /// Extension trait that adds convenience methods to the `u32` type
@@ -72,7 +72,7 @@ impl Into<KiloHertz> for MegaHertz {
 }
 
 /// A monotonic nondecreasing timer
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct MonoTimer {
     frequency: Hertz,
 }
@@ -104,7 +104,7 @@ impl MonoTimer {
 }
 
 /// A measurement of a monotonically nondecreasing clock
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Instant {
     now: u32,
 }


### PR DESCRIPTION
Here's a first go at RNG. Since it's "unproven" in HAL, I added it here as well

Some things that don't strictly belong, so you may object:
- Only available behind stm32l4x2 feature flag, as I can't test it elsewhere (are all the things exposed in lib.rs really available for all l4x1-6?)
- I add some (I believe) helpful methods which aren't defined in the HAL, such as `Rng.is_data_ready()`, with the opinion that a specific HAL should make the given device easy to use (without keeping all registers in one's head at all times). Philosophies may differ here :) Interested in your thoughts.
- I made LSI optional (default on), in line with the optional HSI48 (default off) which RNG needs, and since it's not needed in all cases. This may break other implementations for peripherals which implicitly rely on a running LSI, do they?
- I added some derived Debug traits, it's quite annoying not to have it in some situations (might even derive Serialize and Deserialize, at some point I'd like to use https://github.com/pyfisch/cbor/issues/79)
- I implemented fmt::Write for Tx<USART> since I want to output the collected entropy in `examples/rng.rs`; my understanding is this doesn't bloat code which doesn't use it?