### PR TITLE
Refactor #30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ stm32l4x2 = ["stm32l4/stm32l4x2"]
 stm32l4x3 = ["stm32l4/stm32l4x3"]
 stm32l4x5 = ["stm32l4/stm32l4x5"]
 stm32l4x6 = ["stm32l4/stm32l4x6"]
-stm32l47x = ["stm32l4x6"]
 unproven = ["embedded-hal/unproven"]
 
 [dev-dependencies]

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -54,11 +54,10 @@ impl RccExt for RCC {
             apb2: APB2 { _0: () },
             bdcr: BDCR { _0: () },
             csr: CSR { _0: () },
-            #[cfg(not(feature = "stm32l47x"))]
+            #[cfg(not(feature = "stm32l4x6"))]
             crrcr: CRRCR { _0: () },
             cfgr: CFGR {
                 hclk: None,
-                #[cfg(not(feature = "stm32l47x"))]
                 hsi48: false,
                 msi: None,
                 lsi: false,
@@ -92,7 +91,7 @@ pub struct Rcc {
     /// Control/Status Register
     pub csr: CSR,
     /// Clock recovery RC register
-    #[cfg(not(feature = "stm32l47x"))]
+    #[cfg(not(feature = "stm32l4x6"))]
     pub crrcr: CRRCR,
 }
 
@@ -111,12 +110,12 @@ impl CSR {
 }
 
 /// Clock recovery RC register
-#[cfg(not(feature = "stm32l47x"))]
+#[cfg(not(feature = "stm32l4x6"))]
 pub struct CRRCR {
     _0: (),
 }
 
-#[cfg(not(feature = "stm32l47x"))]
+#[cfg(not(feature = "stm32l4x6"))]
 impl CRRCR {
     // TODO remove `allow`
     #[allow(dead_code)]
@@ -263,8 +262,6 @@ const HSI: u32 = 16_000_000; // Hz
 /// Clock configuration
 pub struct CFGR {
     hclk: Option<u32>,
-    // should we use an option? it can really only be on/off
-    #[cfg(not(feature = "stm32l47x"))]
     hsi48: bool,
     msi: Option<MsiFreq>,
     lsi: bool,
@@ -284,8 +281,8 @@ impl CFGR {
         self
     }
 
-    /// Enable the 48Mh USB, RNG, SDMMC clock source.
-    #[cfg(not(feature = "stm32l47x"))]
+    /// Enable the 48Mh USB, RNG, SDMMC clock source. Not available on stm32l4x6 series
+    #[cfg(not(feature = "stm32l4x6"))]
     pub fn hsi48(mut self, on: bool) -> Self
     {
         self.hsi48 = on;
@@ -343,7 +340,7 @@ impl CFGR {
     }
 
     /// Freezes the clock configuration, making it effective
-    pub fn common_freeze(&self, acr: &mut ACR) -> (Hertz, Hertz, Hertz, u8, u8, Hertz){
+    pub fn freeze(&self, acr: &mut ACR) -> Clocks {
 
         let pllconf = if self.pllcfg.is_none() {
             let plln = (2 * self.sysclk.unwrap_or(HSI)) / HSI;
@@ -507,64 +504,33 @@ impl CFGR {
             while rcc.cr.read().msirdy().bit_is_clear() {}
         }
 
-        (Hertz(hclk), Hertz(pclk1), Hertz(pclk2), ppre1, ppre2, Hertz(sysclk))
-    }
-
-
-    #[cfg(not(feature = "stm32l47x"))]
-    pub fn freeze(self, acr: &mut ACR) -> Clocks {
-
-        let (hclk, pclk1, pclk2, ppre1, ppre2, sysclk) = self.common_freeze(acr);
-        let mut usb_rng = false;
-
-        let rcc = unsafe { &*RCC::ptr() };
-        // Turn on USB, RNG Clock using the HSI48CLK source (default)
-        if !cfg!(feature = "stm32l47x") && self.hsi48 {
-            // p. 180 in ref-manual
-            rcc.crrcr.modify(|_, w| w.hsi48on().set_bit());
-            // Wait until HSI48 is running
-            while rcc.crrcr.read().hsi48rdy().bit_is_clear() {}
-            usb_rng = true;
+        #[cfg(not(feature = "stm32l4x6"))]
+        {
+            // Turn on USB, RNG Clock using the HSI48 CLK source (default)
+            if self.hsi48 {
+                // p. 180 in ref-manual
+                rcc.crrcr.modify(|_, w| w.hsi48on().set_bit());
+                // Wait until HSI48 is running
+                while rcc.crrcr.read().hsi48rdy().bit_is_clear() {}
+            }
         }
 
-        Clocks {
-            hclk,
-            lsi: self.lsi,
-            hsi48: self.hsi48,
-            usb_rng,
-            msi: self.msi,
-            pclk1,
-            pclk2,
-            ppre1,
-            ppre2,
-            sysclk,
-        }
-    }
-
-    #[cfg(feature = "stm32l47x")]
-    pub fn freeze(self, acr: &mut ACR) -> Clocks {
-
-        let (hclk, pclk1, pclk2, ppre1, ppre2, sysclk) = self.common_freeze(acr);
-
-        let mut usb_rng = false;
-
-        let rcc = unsafe { &*RCC::ptr() };
         // Select MSI as clock source for usb48, rng ...
         if let Some(MsiFreq::RANGE48M) = self.msi {
-            unsafe { rcc.ccipr.modify(|_, w| w.clk48sel().bits(0b11)) };
-            usb_rng = true;
+            unsafe { rcc.ccipr.modify(|_, w| w.clk48sel().bits(MsiFreq::RANGE48M as u8)) };
         }
+        //TODO proper clk48sel and other selects
 
         Clocks {
-            hclk,
+            hclk: Hertz(hclk),
             lsi: self.lsi,
-            usb_rng,
             msi: self.msi,
-            pclk1,
-            pclk2,
-            ppre1,
-            ppre2,
-            sysclk,
+            hsi48: self.hsi48,
+            pclk1: Hertz(pclk1),
+            pclk2: Hertz(pclk2),
+            ppre1: ppre1,
+            ppre2: ppre2,
+            sysclk: Hertz(sysclk),
         }
     }
 
@@ -587,9 +553,7 @@ pub struct PllConfig {
 #[derive(Clone, Copy, Debug)]
 pub struct Clocks {
     hclk: Hertz,
-    #[cfg(not(feature = "stm32l47x"))]
     hsi48: bool,
-    usb_rng: bool,
     msi: Option<MsiFreq>,
     lsi: bool,
     pclk1: Hertz,
@@ -608,14 +572,13 @@ impl Clocks {
     }
 
     /// Returns status of HSI48
-    #[cfg(not(feature = "stm32l47x"))]
     pub fn hsi48(&self) -> bool {
         self.hsi48
     }
 
-    /// Returns if usb rng clock is available
-    pub fn usb_rng(&self) -> bool {
-        self.usb_rng
+    // Returns the status of the MSI
+    pub fn msi(&self) -> Option<MsiFreq> {
+        self.msi
     }
 
     /// Returns status of HSI48

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -54,7 +54,6 @@ impl RccExt for RCC {
             apb2: APB2 { _0: () },
             bdcr: BDCR { _0: () },
             csr: CSR { _0: () },
-            #[cfg(not(feature = "stm32l4x6"))]
             crrcr: CRRCR { _0: () },
             cfgr: CFGR {
                 hclk: None,
@@ -91,7 +90,6 @@ pub struct Rcc {
     /// Control/Status Register
     pub csr: CSR,
     /// Clock recovery RC register
-    #[cfg(not(feature = "stm32l4x6"))]
     pub crrcr: CRRCR,
 }
 
@@ -110,12 +108,10 @@ impl CSR {
 }
 
 /// Clock recovery RC register
-#[cfg(not(feature = "stm32l4x6"))]
 pub struct CRRCR {
     _0: (),
 }
 
-#[cfg(not(feature = "stm32l4x6"))]
 impl CRRCR {
     // TODO remove `allow`
     #[allow(dead_code)]
@@ -281,8 +277,7 @@ impl CFGR {
         self
     }
 
-    /// Enable the 48Mh USB, RNG, SDMMC clock source. Not available on stm32l4x6 series
-    #[cfg(not(feature = "stm32l4x6"))]
+    /// Enable the 48Mh USB, RNG, SDMMC clock source. Not available on all stm32l4x6 series
     pub fn hsi48(mut self, on: bool) -> Self
     {
         self.hsi48 = on;
@@ -504,7 +499,6 @@ impl CFGR {
             while rcc.cr.read().msirdy().bit_is_clear() {}
         }
 
-        #[cfg(not(feature = "stm32l4x6"))]
         {
             // Turn on USB, RNG Clock using the HSI48 CLK source (default)
             if self.hsi48 {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -20,14 +20,12 @@ impl RngExt for RNG {
         // ...this is now supposed to be done in RCC configuration before freezing
 
         // hsi48 should be turned on previously or msi at 48mhz
-        let enabled = {
-            clocks.hsi48() ||
-            match clocks.msi() {
-                Some(msi) => msi == crate::rcc::MsiFreq::RANGE48M,
-                None => false,
-            }
+        let msi = match clocks.msi() {
+            Some(msi) => msi == crate::rcc::MsiFreq::RANGE48M,
+            None => false,
         };
-        assert!(enabled);
+        let hsi = clocks.hsi48();
+        assert!(msi || hsi);
 
         ahb2.enr().modify(|_, w| w.rngen().set_bit());
         // if we don't do this... we can be "too fast", and

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -19,9 +19,15 @@ impl RngExt for RNG {
         // crrcr.crrcr().modify(|_, w| w.hsi48on().set_bit()); // p. 180 in ref-manual
         // ...this is now supposed to be done in RCC configuration before freezing
 
-        // hsi48 should be turned on previously
-        // TODO: should we return a Result instead of asserting here?
-        assert!(clocks.usb_rng());
+        // hsi48 should be turned on previously or msi at 48mhz
+        let enabled = {
+            clocks.hsi48() ||
+            match clocks.msi() {
+                Some(msi) => msi == crate::rcc::MsiFreq::RANGE48M,
+                None => false,
+            }
+        };
+        assert!(enabled);
 
         ahb2.enr().modify(|_, w| w.rngen().set_bit());
         // if we don't do this... we can be "too fast", and


### PR DESCRIPTION
Based on the comments from @nickray and my own thoughts:

- Remove stm32l47x feature, replaced by a more generic stm32l4x6, due to regressions, see #32
- hsi48 will always be available in `Clocks`, but for stm32l4x6 devices the method to set it is not available
- remove duplicate freezes, opting to instead conditionally compile the specific code
- remove `usb_rng`, `Clocks` is used to detect if a peripheral has the right clocks or not* see `rng.rs`.

@mathk this will introduce some breaking changes for you, but nothing too severe I hope.

\* _The clock selection still needs to be implemented properly._