### PR TITLE
PWM

### DIFF
--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,0 +1,83 @@
+//! Testing PWM output
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+// use cortex_m::asm;
+use stm32l4xx_hal::{
+    prelude::*,
+    stm32,
+    delay,
+};
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let c = cortex_m::Peripherals::take().unwrap();
+    let p = stm32::Peripherals::take().unwrap();
+
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
+
+    // TIM2
+    let c1 = gpioa.pa0
+        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
+        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+    let c2 = gpioa.pa1
+        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
+        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+    let c3 = gpioa.pa2
+        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
+        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+    let c4 = gpioa.pa3
+        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
+        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+
+    let mut pwm = p
+        .TIM2
+        .pwm(
+            (c1, c2, c3, c4),
+            1.khz(),
+            clocks,
+            &mut rcc.apb1r1,
+        )
+        .3;
+
+    let max = pwm.get_max_duty();
+
+    pwm.enable();
+
+    let mut timer = delay::Delay::new(c.SYST, clocks);
+    let second: u32 = 100;
+
+    loop {
+        pwm.set_duty(max);
+        timer.delay_ms(second);
+        // asm::bkpt();
+
+        pwm.set_duty(max/11*10);
+        timer.delay_ms(second);
+        // asm::bkpt();
+
+        pwm.set_duty(3*max/4);
+        timer.delay_ms(second);
+        // asm::bkpt();
+
+        pwm.set_duty(max/2);
+        timer.delay_ms(second);
+        // asm::bkpt();
+
+        pwm.set_duty(max/4);
+        timer.delay_ms(second);
+        // asm::bkpt();
+
+    }
+}

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -58,6 +58,8 @@ fn main() -> ! {
     let mut timer = delay::Delay::new(c.SYST, clocks);
     let second: u32 = 100;
 
+    // NB: if the pins are LEDs, brightness is not
+    //     linear in duty value.
     loop {
         pwm.set_duty(max);
         timer.delay_ms(second);

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -1,0 +1,36 @@
+//! Bit banding
+
+// seems this is not a HAL trait (yet?)
+// TODO: why is it used
+//
+// "The processor memory map includes two bit-band regions.
+// These occupy the lowest 1MB of the SRAM and Peripheral memory regions respectively.
+// These bit-band regions map each word in an alias region of memory to a bit
+// in a bit-band region of memory."
+//
+// This module only handles peripheral, not SRAM bit-banding
+
+use core::ptr;
+
+pub fn clear<T>(register: *const T, bit: u8) {
+    write(register, bit, false);
+}
+
+pub fn set<T>(register: *const T, bit: u8) {
+    write(register, bit, true);
+}
+
+pub fn write<T>(register: *const T, bit: u8, set: bool) {
+    let addr = register as usize;
+
+    // Peripheral memory starts at 0x4000_0000, the first megabyte is aliased.
+    //
+    // Bit-band region is first megabyte
+    assert!(addr >= 0x4000_0000 && addr <= 0x4010_0000);
+    assert!(bit < 32);
+
+    let bit = bit as usize;
+    // bit_word_addr = bit_band_base + (byte_offset x 32) + (bit_number × 4)
+    let bb_addr = (0x4200_0000 + (addr - 0x4000_0000) * 32) + 4 * bit;
+    unsafe { ptr::write_volatile(bb_addr as *mut u32, if set { 1 } else { 0 }) }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -509,6 +509,7 @@ macro_rules! gpio {
 
                         // set pin high/low before activating, to prevent
                         // spurious signals (e.g. LED flash)
+                        // TODO: I still see a flash of LED using this order
                         match initial_state {
                             State::High => res.set_high(),
                             State::Low => res.set_low(),

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -111,7 +111,9 @@ macro_rules! gpio {
 
             use crate::rcc::AHB2;
             use super::{
-                Alternate, AF4, AF5, AF6, AF7, AF8, AF9, Floating, GpioExt, Input, OpenDrain, Output,
+                Alternate,
+                AF1, AF4, AF5, AF6, AF7, AF8, AF9,
+                Floating, GpioExt, Input, OpenDrain, Output,
                 PullDown, PullUp, PushPull, State,
             };
 
@@ -236,6 +238,29 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> $PXi<MODE> {
+                    /// Configures the pin to serve as alternate function 1 (AF1)
+                    pub fn into_af1(
+                        self,
+                        moder: &mut MODER,
+                        afr: &mut $AFR,
+                    ) -> $PXi<Alternate<AF1, MODE>> {
+                        let offset = 2 * $i;
+
+                        // alternate function mode
+                        let mode = 0b10;
+                        moder.moder().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b11 << offset)) | (mode << offset))
+                        });
+
+                        let af = 1;
+                        let offset = 4 * ($i % 8);
+                        afr.afr().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b1111 << offset)) | (af << offset))
+                        });
+
+                        $PXi { _mode: PhantomData }
+                    }
+
                     /// Configures the pin to serve as alternate function 4 (AF4)
                     pub fn into_af4(
                         self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,3 +165,19 @@ pub mod timer;
     feature = "stm32l4x6"
 ))]
 pub mod tsc;
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x3",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6"
+))]
+pub mod bb;
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x3",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6"
+))]
+pub mod pwm;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,3 +10,4 @@ pub use crate::datetime::U32Ext as _stm32l4_hal_datetime_U32Ext;
 pub use crate::dma::DmaExt as _stm32l4_hal_DmaExt;
 pub use crate::pwr::PwrExt as _stm32l4_hal_PwrExt;
 pub use crate::rng::RngExt as _stm32l4_hal_RngExt;
+pub use crate::pwm::PwmExt as _stm32l4_hal_PwmExt;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1,0 +1,283 @@
+//! # Pulse Width Modulation
+
+use core::marker::PhantomData;
+use core::mem;
+
+use cast::{u16, u32};
+use crate::hal;
+use crate::stm32::TIM2;
+
+use crate::bb;
+use crate::gpio::gpioa::{PA0, PA1, PA2, PA3};
+use crate::gpio::{Alternate, Output, PushPull, AF1};
+use crate::rcc::{Clocks, /* AHB2, */ APB1R1};
+use crate::time::Hertz;
+// use crate::timer::PclkSrc;
+
+pub trait Pins<TIM> {
+    const REMAP: u8;
+    const C1: bool;
+    const C2: bool;
+    const C3: bool;
+    const C4: bool;
+    type Channels;
+}
+
+impl Pins<TIM2>
+    for (
+        PA0<Alternate<AF1, Output<PushPull>>>,
+        PA1<Alternate<AF1, Output<PushPull>>>,
+        PA2<Alternate<AF1, Output<PushPull>>>,
+        PA3<Alternate<AF1, Output<PushPull>>>,
+    )
+{
+    const REMAP: u8 = 0b00;
+    const C1: bool = true;
+    const C2: bool = true;
+    const C3: bool = true;
+    const C4: bool = true;
+    type Channels = (Pwm<TIM2, C1>, Pwm<TIM2, C2>, Pwm<TIM2, C3>, Pwm<TIM2, C4>);
+}
+
+impl Pins<TIM2>
+    for (
+        PA1<Alternate<AF1, Output<PushPull>>>,
+        PA2<Alternate<AF1, Output<PushPull>>>,
+        PA3<Alternate<AF1, Output<PushPull>>>,
+    )
+{
+    const REMAP: u8 = 0b00;
+    const C1: bool = true;
+    const C2: bool = true;
+    const C3: bool = true;
+    const C4: bool = false;
+    type Channels = (Pwm<TIM2, C1>, Pwm<TIM2, C2>, Pwm<TIM2, C3>);
+}
+
+impl Pins<TIM2> for PA0<Alternate<AF1, Output<PushPull>>> {
+    const REMAP: u8 = 0b00;
+    const C1: bool = true;
+    const C2: bool = false;
+    const C3: bool = false;
+    const C4: bool = false;
+    type Channels = Pwm<TIM2, C1>;
+}
+
+pub trait PwmExt: Sized {
+    fn pwm<PINS, T>(
+        self,
+        _: PINS,
+        frequency: T,
+        clocks: Clocks,
+        apb: &mut APB1R1,
+    ) -> PINS::Channels
+    where
+        PINS: Pins<Self>,
+        T: Into<Hertz>;
+}
+
+impl PwmExt for TIM2 {
+    fn pwm<PINS, T>(
+        self,
+        _pins: PINS,
+        freq: T,
+        clocks: Clocks,
+        apb: &mut APB1R1,
+    ) -> PINS::Channels
+    where
+        PINS: Pins<Self>,
+        T: Into<Hertz>,
+    {
+        // TODO: check if this is really not needed (in the f1xx examples value
+        //       of remap is 0x0. in which case, what's afio.mapr on l4xx?
+        //
+        // mapr.mapr()
+        //     .modify(|_, w| unsafe { w.tim2_remap().bits(PINS::REMAP) });
+
+        tim2(self, _pins, freq.into(), clocks, apb)
+    }
+}
+
+pub struct Pwm<TIM, CHANNEL> {
+    _channel: PhantomData<CHANNEL>,
+    _tim: PhantomData<TIM>,
+}
+
+pub struct C1;
+pub struct C2;
+pub struct C3;
+pub struct C4;
+
+macro_rules! hal {
+    ($($TIMX:ident: ($timX:ident, $timXen:ident, $timXrst:ident, $apb:ident),)+) => {
+        $(
+            fn $timX<PINS>(
+                tim: $TIMX,
+                _pins: PINS,
+                freq: Hertz,
+                clocks: Clocks,
+                apb: &mut $apb,
+            ) -> PINS::Channels
+            where
+                PINS: Pins<$TIMX>,
+            {
+                apb.enr().modify(|_, w| w.$timXen().set_bit());
+                apb.rstr().modify(|_, w| w.$timXrst().set_bit());
+                apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
+
+                if PINS::C1 {
+                    tim.ccmr1_output
+                        .modify(|_, w| unsafe { w.oc1pe().set_bit().oc1m().bits(6) });
+                }
+
+                if PINS::C2 {
+                    tim.ccmr1_output
+                        .modify(|_, w| unsafe { w.oc2pe().set_bit().oc2m().bits(6) });
+                }
+
+                if PINS::C3 {
+                    tim.ccmr2_output
+                        .modify(|_, w| unsafe { w.oc3pe().set_bit().oc3m().bits(6) });
+                }
+
+                if PINS::C4 {
+                    tim.ccmr2_output
+                        .modify(|_, w| unsafe { w.oc4pe().set_bit().oc4m().bits(6) });
+                }
+                let clk = clocks.pclk1().0; //$TIMX::get_clk(&clocks).0;
+                let freq = freq.0;
+                // let ticks = clk / freq;
+                let ticks = clk / freq; // TODO check pclk that timer is on
+
+                let psc = u16(ticks / (1 << 16)).unwrap();
+                tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+                let arr = u16(ticks / u32(psc + 1)).unwrap();
+                tim.arr.write(|w| { w.arr().bits(u32(arr)) });
+
+                    // let psc = u16((ticks - 1) / (1 << 16)).unwrap();
+
+                    // self.tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+
+                    // let arr = u16(ticks / u32(psc + 1)).unwrap();
+
+                    // self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
+
+                tim.cr1.write(|w| unsafe {
+                    w.cms()
+                        .bits(0b00)
+                        .dir()
+                        .clear_bit()
+                        .opm()
+                        .clear_bit()
+                        .cen()
+                        .set_bit()
+                });
+
+                unsafe { mem::uninitialized() }
+            }
+
+            impl hal::PwmPin for Pwm<$TIMX, C1> {
+                type Duty = u16;
+
+                fn disable(&mut self) {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) }
+                }
+
+                fn enable(&mut self) {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) }
+                }
+
+                fn get_duty(&self) -> u16 {
+                    // unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() }
+                    unsafe { u16((*$TIMX::ptr()).ccr1.read().ccr1().bits()).unwrap() }
+                }
+
+                fn get_max_duty(&self) -> u16 {
+                    // unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
+                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                }
+
+                fn set_duty(&mut self, duty: u16) {
+                    // unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1().bits(u32(duty))) }
+                }
+            }
+
+            impl hal::PwmPin for Pwm<$TIMX, C2> {
+                type Duty = u16;
+
+                fn disable(&mut self) {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) }
+                }
+
+                fn enable(&mut self) {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) }
+                }
+
+                fn get_duty(&self) -> u16 {
+                    unsafe { u16((*$TIMX::ptr()).ccr2.read().ccr2().bits()).unwrap() }
+                }
+
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                }
+
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr2().bits(u32(duty))) }
+                }
+            }
+
+            impl hal::PwmPin for Pwm<$TIMX, C3> {
+                type Duty = u16;
+
+                fn disable(&mut self) {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 8) }
+                }
+
+                fn enable(&mut self) {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 8) }
+                }
+
+                fn get_duty(&self) -> u16 {
+                    unsafe { u16((*$TIMX::ptr()).ccr3.read().ccr3().bits()).unwrap() }
+                }
+
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                }
+
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr3().bits(u32(duty))) }
+                }
+            }
+
+            impl hal::PwmPin for Pwm<$TIMX, C4> {
+                type Duty = u16;
+
+                fn disable(&mut self) {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 12) }
+                }
+
+                fn enable(&mut self) {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 12) }
+                }
+
+                fn get_duty(&self) -> u16 {
+                    unsafe { u16((*$TIMX::ptr()).ccr4.read().ccr4().bits()).unwrap() }
+                }
+
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                }
+
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr4().bits(u32(duty))) }
+                }
+            }
+        )+
+    }
+}
+
+hal! {
+    TIM2: (tim2, tim2en, tim2rst, APB1R1),
+}

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -124,8 +124,6 @@ macro_rules! hal {
             {
                 apb.enr().modify(|_, w| w.$timXen().set_bit());
                 apb.rstr().modify(|_, w| w.$timXrst().set_bit());
-                // commented line is probably FUD
-                // while apb.rstr().read().$timXrst().bit_is_clear() {}
                 apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
                 if PINS::C1 {

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -166,7 +166,7 @@ macro_rules! hal {
             }
 
             impl hal::PwmPin for Pwm<$TIMX, C1> {
-                type Duty = u16;
+                type Duty = u32;
 
                 fn disable(&mut self) {
                     unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) }
@@ -176,21 +176,21 @@ macro_rules! hal {
                     unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) }
                 }
 
-                fn get_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).ccr1.read().ccr1().bits()).unwrap() }
+                fn get_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr1().bits() }
                 }
 
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                fn get_max_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
                 }
 
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1().bits(u32(duty))) }
+                fn set_duty(&mut self, duty: Self::Duty) {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1().bits(duty)) }
                 }
             }
 
             impl hal::PwmPin for Pwm<$TIMX, C2> {
-                type Duty = u16;
+                type Duty = u32;
 
                 fn disable(&mut self) {
                     unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) }
@@ -200,21 +200,21 @@ macro_rules! hal {
                     unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) }
                 }
 
-                fn get_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).ccr2.read().ccr2().bits()).unwrap() }
+                fn get_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr2().bits() }
                 }
 
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                fn get_max_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
                 }
 
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr2().bits(u32(duty))) }
+                fn set_duty(&mut self, duty: Self::Duty) {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr2().bits(duty)) }
                 }
             }
 
             impl hal::PwmPin for Pwm<$TIMX, C3> {
-                type Duty = u16;
+                type Duty = u32;
 
                 fn disable(&mut self) {
                     unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 8) }
@@ -224,21 +224,21 @@ macro_rules! hal {
                     unsafe { bb::set(&(*$TIMX::ptr()).ccer, 8) }
                 }
 
-                fn get_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).ccr3.read().ccr3().bits()).unwrap() }
+                fn get_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr3().bits() }
                 }
 
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                fn get_max_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
                 }
 
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr3().bits(u32(duty))) }
+                fn set_duty(&mut self, duty: Self::Duty) {
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr3().bits(duty)) }
                 }
             }
 
             impl hal::PwmPin for Pwm<$TIMX, C4> {
-                type Duty = u16;
+                type Duty = u32;
 
                 fn disable(&mut self) {
                     unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 12) }
@@ -248,16 +248,16 @@ macro_rules! hal {
                     unsafe { bb::set(&(*$TIMX::ptr()).ccer, 12) }
                 }
 
-                fn get_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).ccr4.read().ccr4().bits()).unwrap() }
+                fn get_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr4().bits() }
                 }
 
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { u16((*$TIMX::ptr()).arr.read().arr().bits()).unwrap() }
+                fn get_max_duty(&self) -> Self::Duty {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
                 }
 
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr4().bits(u32(duty))) }
+                fn set_duty(&mut self, duty: Self::Duty) {
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr4().bits(duty)) }
                 }
             }
         )+


### PR DESCRIPTION
I needed PWM to dim an RGB LED on https://github.com/solokeys/solo-bsc, so I added minimal support for TIM2, based on [the f1xx implementation](https://github.com/stm32-rs/stm32f1xx-hal/blob/master/src/pwm.rs). Thoughts?

- type Duty [is choosable](https://docs.rs/embedded-hal/0.2.2/embedded_hal/trait.Pwm.html#associatedtype.Duty). Instead of u16 as in f1xx, I'm using u32. Effectively, max_duty seems to be 16_000
- this PR also sneaks in `bb` (bit-banding), I'm not sure if the implementation uses it for convenience or by necessity
- gpio `push_pull_output` gets a `push_pull_output_with_state` as for f1xx. This should be useful as e.g. some LEDs are off when the pin is high. However, it seems my implementation (probably theirs too) does not prevent a flash/signal passing through