### PR TITLE
Use 0.7.0 PAC and fix PWM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-stm32l4 = "0.6.0"
+stm32l4 = "0.7.0"
 as-slice = "0.1"
 
 [dependencies.cast]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -112,7 +112,7 @@ macro_rules! gpio {
             use crate::rcc::AHB2;
             use super::{
                 Alternate,
-                AF1, AF4, AF5, AF6, AF7, AF8, AF9,
+                AF1, AF4, AF5, AF6, AF7, AF8, AF9, AF10,
                 Floating, GpioExt, Input, OpenDrain, Output,
                 PullDown, PullUp, PushPull, State,
             };
@@ -393,6 +393,30 @@ macro_rules! gpio {
                         });
 
                         let af = 9;
+                        let offset = 4 * ($i % 8);
+
+                        afr.afr().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b1111 << offset)) | (af << offset))
+                        });
+
+                        $PXi { _mode: PhantomData }
+                    }
+
+                    /// Configures the pin to serve as alternate function 10 (AF10)
+                    pub fn into_af10(
+                        self,
+                        moder: &mut MODER,
+                        afr: &mut $AFR,
+                    ) -> $PXi<Alternate<AF10, MODE>> {
+                        let offset = 2 * $i;
+
+                        // alternate function mode
+                        let mode = 0b10;
+                        moder.moder().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b11 << offset)) | (mode << offset))
+                        });
+
+                        let af = 10;
                         let offset = 4 * ($i % 8);
 
                         afr.afr().modify(|r, w| unsafe {

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -192,7 +192,7 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> Self::Duty {
-                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr1().bits() }
+                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() }
                 }
 
                 fn get_max_duty(&self) -> Self::Duty {
@@ -200,7 +200,7 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: Self::Duty) {
-                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1().bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty)) }
                 }
             }
 
@@ -216,7 +216,7 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> Self::Duty {
-                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr2().bits() }
+                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() }
                 }
 
                 fn get_max_duty(&self) -> Self::Duty {
@@ -224,7 +224,7 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: Self::Duty) {
-                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr2().bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty)) }
                 }
             }
 
@@ -240,7 +240,7 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> Self::Duty {
-                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr3().bits() }
+                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() }
                 }
 
                 fn get_max_duty(&self) -> Self::Duty {
@@ -248,7 +248,7 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: Self::Duty) {
-                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr3().bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty)) }
                 }
             }
 
@@ -264,7 +264,7 @@ macro_rules! hal {
                 }
 
                 fn get_duty(&self) -> Self::Duty {
-                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr4().bits() }
+                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() }
                 }
 
                 fn get_max_duty(&self) -> Self::Duty {
@@ -272,7 +272,7 @@ macro_rules! hal {
                 }
 
                 fn set_duty(&mut self, duty: Self::Duty) {
-                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr4().bits(duty)) }
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty)) }
                 }
             }
         )+


### PR DESCRIPTION
This is only tested for feature `stm32l4x2`.
The register naming for TIM2_CCRx changed in the v0.7.0 PAC.