### PR TITLE
Updated digital traits for gpio to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default-features = false
 version = "1.1"
 
 [dependencies.embedded-hal]
-version = "0.2.2"
+version = "0.2.3"
 features = ["unproven"]
 
 [package.metadata.docs.rs]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,7 @@
 //! Prelude - Include traits for hal
 
 pub use crate::hal::prelude::*; // embedded hal traits
+pub use crate::hal::digital::v2::*; // for some reason v2 is not exported in the ehal prelude
 
 pub use crate::rcc::RccExt as _stm32l4_hal_RccExt;
 pub use crate::flash::FlashExt as _stm32l4_hal_FlashExt;


### PR DESCRIPTION
Closes #63.

Not a massive fan on this change, I wish the ehal provided infallible traits that don't require unwraps on what is essentially volatile reads and writes in our case; but the warnings are very annoying so this gets rid of them.