### PR TITLE
Replace Gpio error type with infallible

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -136,6 +136,7 @@ macro_rules! gpio {
         /// GPIO
         pub mod $gpiox {
             use core::marker::PhantomData;
+            use core::convert::Infallible;
 
             use crate::hal::digital::v2::{OutputPin, InputPin};
             use crate::stm32::{$gpioy, $GPIOX};
@@ -249,7 +250,7 @@ macro_rules! gpio {
             }
 
             impl<MODE> OutputPin for $PXx<Output<MODE>> {
-                type Error = ();
+                type Error = Infallible;
 
                 fn set_high(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
@@ -454,7 +455,7 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
-                    type Error = ();
+                    type Error = Infallible;
                     
                     fn set_high(&mut self) -> Result<(), Self::Error> {
                         // NOTE(unsafe) atomic write to a stateless register
@@ -470,7 +471,7 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> InputPin for $PXi<Input<MODE>> {
-                    type Error = ();
+                    type Error = Infallible;
 
                     fn is_high(&self) -> Result<bool, Self::Error> {
                         Ok(!self.is_low().unwrap())


### PR DESCRIPTION
Remove the () type from the gpio error type, instead using a more suitable Infallible error type.