### PR TITLE
Feature(gpio)/exti

### DIFF
--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -1,0 +1,74 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting; // logs messages to the host stderr; requires a debugger
+extern crate stm32l4xx_hal as hal;
+
+use crate::hal::{
+    gpio::{gpioc::PC13, Edge, ExtiPin, Input, PullUp},
+    interrupt,
+    prelude::*,
+    rcc::{Clocks, Rcc},
+    stm32,
+};
+use core::cell::{Cell, RefCell};
+use core::fmt;
+use core::ops::DerefMut;
+use cortex_m::interrupt::{free, CriticalSection, Mutex};
+use cortex_m_rt::entry;
+
+// Set up global state. It's all mutexed up for concurrency safety.
+static BUTTON: Mutex<RefCell<Option<PC13<Input<PullUp>>>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    if let (Some(mut dp), Some(cp)) = (stm32::Peripherals::take(), cortex_m::Peripherals::take()) {
+        dp.RCC.apb2enr.write(|w| w.syscfgen().enabled());
+
+        let rcc = dp.RCC.constrain();
+        let clocks = rcc
+            .cfgr
+            .hclk(48.mhz())
+            .sysclk(48.mhz())
+            .pclk1(24.mhz())
+            .pclk2(24.mhz())
+            .freeze();
+
+        // Create a button input with an interrupt
+        let gpioc = dp.GPIOC.split();
+        let mut board_btn = gpioc
+            .pc13
+            .into_pull_up_input(&mut gpioc.moder, &mut gpioc.pupdr);
+        board_btn.make_interrupt_source(&mut dp.SYSCFG);
+        board_btn.enable_interrupt(&mut dp.EXTI);
+        board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
+
+        // Enable interrupts
+        stm32::NVIC::unpend(hal::interrupt::EXTI15_10);
+        unsafe {
+            stm32::NVIC::unmask(hal::interrupt::EXTI15_10);
+        };
+
+        free(|cs| {
+            BUTTON.borrow(cs).replace(Some(board_btn));
+        });
+
+        loop {}
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn EXTI15_10() {
+    free(|cs| {
+        let mut btn_ref = BUTTON.borrow(cs).borrow_mut();
+        if let Some(ref mut btn) = btn_ref.deref_mut() {
+            if btn.check_interrupt() {
+
+                // if we don't clear this bit, the ISR would trigger indefinitely
+                btn.clear_interrupt_pending_bit();
+            }
+        }
+    });
+}

--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -1,21 +1,21 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_semihosting; // logs messages to the host stderr; requires a debugger
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
 extern crate stm32l4xx_hal as hal;
 
 use crate::hal::{
     gpio::{gpioc::PC13, Edge, ExtiPin, Input, PullUp},
     interrupt,
     prelude::*,
-    rcc::{Clocks, Rcc},
     stm32,
 };
-use core::cell::{Cell, RefCell};
-use core::fmt;
+use core::cell::RefCell;
 use core::ops::DerefMut;
-use cortex_m::interrupt::{free, CriticalSection, Mutex};
-use cortex_m_rt::entry;
+use cortex_m::interrupt::{free, Mutex};
+use rt::entry;
 
 // Set up global state. It's all mutexed up for concurrency safety.
 static BUTTON: Mutex<RefCell<Option<PC13<Input<PullUp>>>>> = Mutex::new(RefCell::new(None));
@@ -23,19 +23,20 @@ static BUTTON: Mutex<RefCell<Option<PC13<Input<PullUp>>>>> = Mutex::new(RefCell:
 #[entry]
 fn main() -> ! {
     if let (Some(mut dp), Some(cp)) = (stm32::Peripherals::take(), cortex_m::Peripherals::take()) {
-        dp.RCC.apb2enr.write(|w| w.syscfgen().enabled());
+        dp.RCC.apb2enr.write(|w| w.syscfgen().set_bit());
 
-        let rcc = dp.RCC.constrain();
-        let clocks = rcc
-            .cfgr
+        let mut rcc = dp.RCC.constrain();
+        let mut flash = dp.FLASH.constrain(); // .constrain();
+
+        rcc.cfgr
             .hclk(48.mhz())
             .sysclk(48.mhz())
             .pclk1(24.mhz())
             .pclk2(24.mhz())
-            .freeze();
+            .freeze(&mut flash.acr);
 
         // Create a button input with an interrupt
-        let gpioc = dp.GPIOC.split();
+        let mut gpioc = dp.GPIOC.split(&mut rcc.ahb2);
         let mut board_btn = gpioc
             .pc13
             .into_pull_up_input(&mut gpioc.moder, &mut gpioc.pupdr);
@@ -44,10 +45,8 @@ fn main() -> ! {
         board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
 
         // Enable interrupts
-        stm32::NVIC::unpend(hal::interrupt::EXTI15_10);
-        unsafe {
-            stm32::NVIC::unmask(hal::interrupt::EXTI15_10);
-        };
+        let mut nvic = cp.NVIC;
+        nvic.enable(stm32::Interrupt::EXTI15_10);
 
         free(|cs| {
             BUTTON.borrow(cs).replace(Some(board_btn));
@@ -65,7 +64,6 @@ fn EXTI15_10() {
         let mut btn_ref = BUTTON.borrow(cs).borrow_mut();
         if let Some(ref mut btn) = btn_ref.deref_mut() {
             if btn.check_interrupt() {
-
                 // if we don't clear this bit, the ISR would trigger indefinitely
                 btn.clear_interrupt_pending_bit();
             }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,7 @@ pub use crate::hal::digital::v2::*; // for some reason v2 is not exported in the
 pub use crate::rcc::RccExt as _stm32l4_hal_RccExt;
 pub use crate::flash::FlashExt as _stm32l4_hal_FlashExt;
 pub use crate::gpio::GpioExt as _stm32l4_hal_GpioExt;
+pub use crate::gpio::ExtiPin as _stm32l4_hal_ExtiPin;
 pub use crate::time::U32Ext as _stm32l4_hal_time_U32Ext;
 pub use crate::datetime::U32Ext as _stm32l4_hal_datetime_U32Ext;
 pub use crate::dma::DmaExt as _stm32l4_hal_DmaExt;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -432,20 +432,13 @@ macro_rules! hal {
                     // NOTE(unsafe) atomic read with no side effects
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 
-                    // NOTE(unsafe): Only used for atomic writes, to clear error flags.
-                    let icr = unsafe { &(*$USARTX::ptr()).icr };
-
                     Err(if isr.pe().bit_is_set() {
-                        icr.write(|w| w.pecf().clear());
                         nb::Error::Other(Error::Parity)
                     } else if isr.fe().bit_is_set() {
-                        icr.write(|w| w.fecf().clear());
                         nb::Error::Other(Error::Framing)
                     } else if isr.nf().bit_is_set() {
-                        icr.write(|w| w.ncf().clear());
                         nb::Error::Other(Error::Noise)
                     } else if isr.ore().bit_is_set() {
-                        icr.write(|w| w.orecf().clear());
                         nb::Error::Other(Error::Overrun)
                     } else if isr.rxne().bit_is_set() {
                         // NOTE(read_volatile) see `write_volatile` below

--- a/src/time.rs
+++ b/src/time.rs
@@ -71,6 +71,16 @@ impl Into<KiloHertz> for MegaHertz {
     }
 }
 
+impl From<u32> for Hertz {
+    fn from(ms: u32) -> Self {
+        if ms >= 1000 {
+            Hertz(1/(ms/1000))
+        } else {
+            Hertz(1)
+        }
+    }
+}
+
 /// A monotonic nondecreasing timer
 #[derive(Clone, Copy, Debug)]
 pub struct MonoTimer {


### PR DESCRIPTION
Add `ExtiPin` trait for GPIO external interrupt settings.

This implementation follows the way it is done in some of the other HAL implementations (https://github.com/stm32-rs/stm32f1xx-hal/blob/master/src/gpio.rs) 

This PR also adds an example on how to use the EXTI on a simple input pin.