### PR TITLE
Added support for HSE, LSE, different PLL sources, PLL calibration of MSI, and some more improvements

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -589,10 +589,15 @@ impl CFGR {
         };
 
         let pllconf = if self.pll_config.is_none() {
-            // Calculate PLL multiplier and create a best effort pll config, just multiply n
-            let plln = (2 * self.sysclk.unwrap_or(HSI)) / clock_speed;
+            if let Some(sysclk) = self.sysclk {
+                // Calculate PLL multiplier and create a best effort pll config, just multiply n
+                let plln = (2 * sysclk) / clock_speed;
 
-            Some(PllConfig::new(1, plln as u8, PllDivider::Div2))
+                Some(PllConfig::new(1, plln as u8, PllDivider::Div2))
+            }
+            else {
+                None
+            }
         } else {
             self.pll_config
         };

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -552,22 +552,18 @@ impl CFGR {
         let (clock_speed, pll_source) = if let Some(source) = self.pll_source {
             match source {
                 PllSource::HSE => {
-                    assert!(self.hse.is_some());
-
                     if let Some(hse) = &self.hse {
                         (hse.speed, source)
                     } else {
-                        unreachable!()
+                        panic!("HSE selected as PLL source, but not enabled");
                     }
                 }
                 PllSource::HSI16 => (HSI, source),
                 PllSource::MSI => {
-                    assert!(self.msi.is_some());
-
                     if let Some(msi) = self.msi {
                         (msi.to_hertz().0, source)
                     } else {
-                        unreachable!()
+                        panic!("MSI selected as PLL source, but not enabled");
                     }
                 }
             }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -590,8 +590,7 @@ impl CFGR {
                 let plln = (2 * sysclk) / clock_speed;
 
                 Some(PllConfig::new(1, plln as u8, PllDivider::Div2))
-            }
-            else {
+            } else {
                 None
             }
         } else {
@@ -748,6 +747,22 @@ impl CFGR {
         }
 
         while rcc.cfgr.read().sws().bits() != sysclk_src_bits {}
+
+        //
+        // 3. Shutdown unused clocks that have auto-started
+        //
+
+        // MSI always starts on reset
+        if self.msi.is_none() {
+            unsafe {
+                rcc.cr
+                    .modify(|_, w| w.msion().clear_bit().msipllen().clear_bit())
+            }
+        }
+
+        //
+        // 4. Clock setup done!
+        //
 
         Clocks {
             hclk: Hertz(hclk),


### PR DESCRIPTION
Hi, I did some refactoring of the RCC module to better support other clock and PLL configs.
We are using the STM32L412CB in our new product, so I will most likely come with a lot of PRs as I develop the codebase for the product. :)

Usage example, where the MSI is used (with PLL calibration and as source to system PLL):
```rust
    let mut flash = dp.FLASH.constrain();
    let rcc = dp.RCC.constrain();

    let clocks = rcc
        .cfgr
        .lse(CrystalBypass::Disable)
        .msi(MsiFreq::RANGE4M)
        .sysclk(80.mhz())
        .pclk1(80.mhz())
        .pclk2(80.mhz())
        .freeze(&mut flash.acr);
``` 

All the best!

Edit: Tested on Nucleo-L412RB