### PR TITLE
Correctly round ms to Hertz in From<u32>

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -1,7 +1,6 @@
 //! Time units
 
 use cortex_m::peripheral::DWT;
-
 use crate::rcc::Clocks;
 
 /// Bits per second
@@ -73,8 +72,8 @@ impl Into<KiloHertz> for MegaHertz {
 
 impl From<u32> for Hertz {
     fn from(ms: u32) -> Self {
-        if ms >= 1000 {
-            Hertz(1/(ms/1000))
+        if ms <= 1000 {
+            Hertz((1_f32/((ms as f32)/1000_f32)) as u32)
         } else {
             Hertz(1)
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -73,7 +73,7 @@ impl Into<KiloHertz> for MegaHertz {
 impl From<u32> for Hertz {
     fn from(ms: u32) -> Self {
         if ms <= 1000 {
-            Hertz((1_f32/((ms as f32)/1000_f32)) as u32)
+            Hertz((1000 + ms / 2) / ms)
         } else {
             Hertz(1)
         }


### PR DESCRIPTION
The current `From<u32>` for Hertz doesn't correctly handle times in between integers. 

This method makes sure that the resulting Hertz will uphold the timer contract of waiting ATLEAST the specified amount of time (as close to correctly as possible with integer Hertz)