### PR TITLE
Made DMAFrame panic free

### DIFF
--- a/src/dma.rs
+++ b/src/dma.rs
@@ -632,8 +632,9 @@ macro_rules! dma {
                                 old_buf.set_len_from_dma(got_data_len as u16);
                             }
 
-                            // 2. Check DMA race condition by finding matched character
-                            let len = if character_match_interrupt {
+                            // 2. Check DMA race condition by finding matched character, and that
+                            //    the length is larger than 0
+                            let len = if character_match_interrupt && got_data_len > 0 {
                                 let search_buf = old_buf.read();
 
                                 // Search from the end
@@ -641,7 +642,8 @@ macro_rules! dma {
                                 if let Some(pos) = search_buf.iter().rposition(|&x| x == ch) {
                                     pos+1
                                 } else {
-                                    panic!("Matching character not found, but got character match interrupt");
+                                    // No character match found
+                                    0
                                 }
                             } else {
                                 old_buf.len()

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -79,7 +79,7 @@ use crate::gpio::gpioc::PC12;
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 use crate::gpio::AF8;
 
-use crate::dma::{dma1, CircBuffer, FrameReader, FrameSender, DMAFrame};
+use crate::dma::{dma1, CircBuffer, DMAFrame, FrameReader, FrameSender};
 use crate::rcc::{Clocks, APB1R1, APB2};
 use crate::time::{Bps, U32Ext};
 


### PR DESCRIPTION
I made the DMAFrame handling panic free, there are cases when the character match interrupt can fire (due to startup value in the USART) so a spurious startup ISR could trigger the panic.
Now the handing will simply return an empty frame which is a safe and panic free alternative.