### PR TITLE
Revert back DMA API to StableDeref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ default-features = false
 version = "1.0.2"
 default-features = false
 
+[dependencies.stable_deref_trait]
+default-features = false
+version = "1.1"
+
 [dependencies.embedded-hal]
 version = "0.2.3"
 features = ["unproven"]

--- a/examples/rtfm_frame_serial_dma.rs
+++ b/examples/rtfm_frame_serial_dma.rs
@@ -8,9 +8,8 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _;
 use hal::{
-    dma::{self, consts, FrameReader, FrameSender, DMAFrame},
+    dma::{self, consts, DMAFrame, FrameReader, FrameSender},
     prelude::*,
     rcc::{ClockSecuritySystem, CrystalBypass, MsiFreq},
     serial::{self, Config, Serial},
@@ -19,11 +18,15 @@ use heapless::{
     pool,
     pool::singleton::{Box, Pool},
 };
+use panic_halt as _;
 use rtfm::app;
 use stm32l4xx_hal as hal;
 
 // The pool gives out `Box<DMAFrame>`s that can hold 8 bytes
-pool!(SerialDMAPool: DMAFrame<consts::U8>);
+pool!(
+    #[allow(non_upper_case_globals)]
+    SerialDMAPool: DMAFrame<consts::U8>
+);
 
 #[app(device = stm32l4xx_hal::stm32, peripherals = true)]
 const APP: () = {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,10 +6,11 @@ use as_slice::AsMutSlice;
 use core::fmt;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use core::ops::{Deref, DerefMut};
+use core::ops::DerefMut;
 use core::ptr;
 use core::sync::atomic::{self, Ordering};
 use generic_array::ArrayLength;
+use stable_deref_trait::StableDeref;
 
 use crate::hal::serial::{self, Write};
 use nb;
@@ -909,7 +910,7 @@ macro_rules! hal {
                     mut buffer: B,
                 ) -> CircBuffer<B, $rx_chan>
                 where
-                    B: Deref<Target = [H; 2]> + DerefMut + 'static,
+                    B: StableDeref<Target = [H; 2]> + DerefMut + 'static,
                     H: AsMutSlice<Element = u8>
                 {
                     let buf = buffer[0].as_mut_slice();
@@ -957,7 +958,7 @@ macro_rules! hal {
                     buffer: BUFFER,
                 ) -> FrameReader<BUFFER, $rx_chan, N>
                     where
-                        BUFFER: Sized + Deref<Target = DMAFrame<N>> + DerefMut + 'static,
+                        BUFFER: Sized + StableDeref<Target = DMAFrame<N>> + DerefMut + 'static,
                         N: ArrayLength<MaybeUninit<u8>>,
                 {
                     let usart = unsafe{ &(*$USARTX::ptr()) };
@@ -1055,7 +1056,7 @@ macro_rules! hal {
                     mut channel: $tx_chan,
                 ) -> FrameSender<BUFFER, $tx_chan, N>
                     where
-                        BUFFER: Sized + Deref<Target = DMAFrame<N>> + DerefMut + 'static,
+                        BUFFER: Sized + StableDeref<Target = DMAFrame<N>> + DerefMut + 'static,
                         N: ArrayLength<MaybeUninit<u8>>,
                 {
                     let usart = unsafe{ &(*$USARTX::ptr()) };


### PR DESCRIPTION
In https://github.com/stm32-rs/stm32l4xx-hal/pull/94 I suggested that there wasn't a need for `StableDeref` if we had `'static`. I was wrong, right now the DMA API is unsound. This PR reverts back to `StableDeref`.

~~Blocked on https://github.com/japaric/heapless/pull/148~~