### PR TITLE
Update examples

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -34,9 +34,10 @@ fn main() -> ! {
 
     let mut flash = dp.FLASH.constrain(); // .constrain();
     let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     // Try a different clock configuration
-    let clocks = rcc.cfgr.hclk(8.mhz()).freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.hclk(8.mhz()).freeze(&mut flash.acr, &mut pwr);
     // let clocks = rcc.cfgr
     //     .sysclk(64.mhz())
     //     .pclk1(32.mhz())

--- a/examples/i2c_write.rs
+++ b/examples/i2c_write.rs
@@ -33,8 +33,9 @@ fn main() -> ! {
 
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
 
     let mut gpioa = dp.GPIOA.split(&mut rcc.ahb2);
 

--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -12,9 +12,12 @@ use crate::hal::{
     prelude::*,
     stm32,
 };
+use cortex_m::{
+    interrupt::{free, Mutex},
+    peripheral::NVIC
+};
 use core::cell::RefCell;
 use core::ops::DerefMut;
-use cortex_m::interrupt::{free, Mutex};
 use rt::entry;
 
 // Set up global state. It's all mutexed up for concurrency safety.
@@ -22,18 +25,16 @@ static BUTTON: Mutex<RefCell<Option<PC13<Input<PullUp>>>>> = Mutex::new(RefCell:
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut dp), Some(cp)) = (stm32::Peripherals::take(), cortex_m::Peripherals::take()) {
+    if let Some(mut dp) = stm32::Peripherals::take() {
         dp.RCC.apb2enr.write(|w| w.syscfgen().set_bit());
 
         let mut rcc = dp.RCC.constrain();
         let mut flash = dp.FLASH.constrain(); // .constrain();
+        let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
         rcc.cfgr
-            .hclk(48.mhz())
-            .sysclk(48.mhz())
-            .pclk1(24.mhz())
-            .pclk2(24.mhz())
-            .freeze(&mut flash.acr);
+            .sysclk(80.mhz())
+            .freeze(&mut flash.acr, &mut pwr);
 
         // Create a button input with an interrupt
         let mut gpioc = dp.GPIOC.split(&mut rcc.ahb2);
@@ -45,8 +46,7 @@ fn main() -> ! {
         board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
 
         // Enable interrupts
-        let mut nvic = cp.NVIC;
-        nvic.enable(stm32::Interrupt::EXTI15_10);
+        unsafe { NVIC::unmask(stm32::Interrupt::EXTI15_10); }
 
         free(|cs| {
             BUTTON.borrow(cs).replace(Some(board_btn));

--- a/examples/pll_config.rs
+++ b/examples/pll_config.rs
@@ -29,6 +29,7 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
@@ -47,7 +48,7 @@ fn main() -> ! {
         .sysclk_with_pll(8.mhz(), plls)
         .pclk1(8.mhz())
         .pclk2(8.mhz())
-        .freeze(&mut flash.acr);
+        .freeze(&mut flash.acr, &mut pwr);
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -22,8 +22,9 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
 
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
 
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
 

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -35,11 +35,12 @@ fn main() -> ! {
 
     let mut flash = device.FLASH.constrain();
     let mut rcc = device.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
 
     let clocks = rcc.cfgr
         .hsi48(true)  // needed for RNG
         .sysclk(64.mhz()).pclk1(32.mhz())
-        .freeze(&mut flash.acr);
+        .freeze(&mut flash.acr, &mut pwr);
 
     // setup usart
     let mut gpioa = device.GPIOA.split(&mut rcc.ahb2);

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -35,12 +35,12 @@ fn main() -> ! {
 
     let mut flash = dp.FLASH.constrain(); // .constrain();
     let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     // Try a different clock configuration
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
 
     let mut timer = Delay::new(cp.SYST, clocks);
-    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
     let rtc = Rtc::rtc(dp.RTC, &mut rcc.apb1r1, &mut rcc.bdcr, &mut pwr.cr1, clocks);
 
     let mut time = Time::new(21.hours(), 57.minutes(), 32.seconds(), false);

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -28,13 +28,19 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
+
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
     // let clocks = rcc.cfgr.freeze(&mut flash.acr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
-    let clocks = rcc.cfgr.sysclk(80.mhz()).pclk1(80.mhz()).pclk2(80.mhz()).freeze(&mut flash.acr);
+    let clocks = rcc.cfgr
+        .sysclk(80.mhz())
+        .pclk1(80.mhz())
+        .pclk2(80.mhz())
+        .freeze(&mut flash.acr, &mut pwr);
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -30,12 +30,14 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
+
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     let channels = p.DMA1.split(&mut rcc.ahb1);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
 

--- a/examples/serial_dma_partial_peek.rs
+++ b/examples/serial_dma_partial_peek.rs
@@ -31,12 +31,14 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
+
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     let channels = p.DMA1.split(&mut rcc.ahb1);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
 

--- a/examples/serial_dma_us2.rs
+++ b/examples/serial_dma_us2.rs
@@ -30,12 +30,14 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
+
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     let channels = p.DMA1.split(&mut rcc.ahb1);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
 

--- a/examples/serial_hw_flow.rs
+++ b/examples/serial_hw_flow.rs
@@ -28,6 +28,8 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
+
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
@@ -39,7 +41,7 @@ fn main() -> ! {
         .sysclk(80.mhz())
         .pclk1(80.mhz())
         .pclk2(80.mhz())
-        .freeze(&mut flash.acr);
+        .freeze(&mut flash.acr, &mut pwr);
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations

--- a/examples/serial_vcom.rs
+++ b/examples/serial_vcom.rs
@@ -27,12 +27,13 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
     // let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
     let mut gpiod = p.GPIOD.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
 

--- a/examples/spi_write.rs
+++ b/examples/spi_write.rs
@@ -29,6 +29,7 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
 
     // TRY the other clock configuration
     // let clocks = rcc.cfgr.freeze(&mut flash.acr);
@@ -37,7 +38,7 @@ fn main() -> ! {
         .sysclk(80.mhz())
         .pclk1(80.mhz())
         .pclk2(80.mhz())
-        .freeze(&mut flash.acr);
+        .freeze(&mut flash.acr, &mut pwr);
 
     let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -30,13 +30,13 @@ fn main() -> ! {
 
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();
-    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     let mut flash = dp.FLASH.constrain(); // .constrain();
     let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     // Try a different clock configuration
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
 
     // let mut gpiob = dp.GPIOB.split(&mut rcc.ahb2);
     // let mut led = gpiob.pb3.into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -30,6 +30,7 @@ fn main() -> ! {
 
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     let mut flash = dp.FLASH.constrain(); // .constrain();
     let mut rcc = dp.RCC.constrain();
@@ -50,8 +51,8 @@ fn main() -> ! {
 
 #[interrupt]
 fn TIM7() {
-    let mut p = 0;
-    p += 1;
+    static mut COUNT: u32 = 0;
+    *COUNT += 1;
     // let mut hstdout = hio::hstdout().unwrap();
     // writeln!(hstdout, "Hello, TIM!").unwrap();
 }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -25,11 +25,12 @@ fn main() -> ! {
 
     let mut flash = p.FLASH.constrain();
     let mut rcc = p.RCC.constrain();
+    let mut pwr = p.PWR.constrain(&mut rcc.apb1r1);
     // let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
     let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
-    let _clocks = rcc.cfgr.freeze(&mut flash.acr);
+    let _clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
 

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -39,6 +39,7 @@ fn main() -> ! {
 
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     let _clocks = rcc
         .cfgr
@@ -46,7 +47,7 @@ fn main() -> ! {
         .sysclk(48.mhz())
         .pclk1(24.mhz())
         .pclk2(24.mhz())
-        .freeze(&mut flash.acr);
+        .freeze(&mut flash.acr, &mut pwr);
 
     enable_crs();
 


### PR DESCRIPTION
## Why?

I grabbed this library to play around with my Nucleo STM32L432KC board and it is great! The examples were a bit outdated though so I wanted to help update them as best as I could. In particular:

- The `nvic.enable` function was depracated for `NVIC::unmask` in cortex-m 0.6.1
  - Source: https://docs.rs/cortex-m/0.6.2/cortex_m/peripheral/struct.NVIC.html#method.enable
- The clock settings on examples using a 48mhz clock cause an assertion failure:

```txt
panicked at 'assertion failed: pllconf.n >= 8', /home/brian/.cargo/git/checkouts/stm32
0x08004568 in __bkpt () │l4xx-hal-8d56012c7770dc85/d3d4382/src/rcc.rs:695:13
```

- The `rcc.cfgr.freeze()` call now also takes a `&mut Pwr` object.

## What Changed?

Added the `pwr` peripheral to the `rcc.cfgr.freeze()` call to all examples.

For some examples, I was able to do additional updates and check them on my Nucleo STM32L432KC board:

### blinky.rs

- :heavy_check_mark: Debugged on an STM32L432KC Nucleo board and confirmed this is working 

### timer.rs

- Updated the NVIC call.
- Changed the timer example to use a `static` variable so that you can see it increasing per call.
- :heavy_check_mark: Debugged on an STM32L432KC Nucleo board and confirmed this is working

### irq_button.rs

- Updated the NVIC call.
- Changed the timer example to use a `static` variable so that you can see it increasing per call.
- Changed the clock configuration to not throw an error.
- :heavy_check_mark: Debugged on an STM32L432KC Nucleo board and confirmed this is working
