### PR TITLE
Feature/Independent Watchdog Timer

### DIFF
--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -1,5 +1,4 @@
-//! Blinks an LED
-
+//! Example of watchdog timer
 #![deny(unsafe_code)]
 // #![deny(warnings)]
 #![no_std]
@@ -40,7 +39,6 @@ fn main() -> ! {
     // Try a different clock configuration
     let clocks = rcc
         .cfgr
-        .lse(CrystalBypass::Disable, ClockSecuritySystem::Disable)
         .lsi(true)
         .freeze(&mut flash.acr, &mut pwr);
     

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -1,0 +1,66 @@
+//! Blinks an LED
+
+#![deny(unsafe_code)]
+// #![deny(warnings)]
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+#[macro_use]
+extern crate cortex_m_rt as rt;
+extern crate cortex_m_semihosting as sh;
+extern crate panic_semihosting;
+extern crate stm32l4xx_hal as hal;
+// #[macro_use(block)]
+// extern crate nb;
+
+use crate::hal::delay::Delay;
+use crate::hal::prelude::*;
+use crate::hal::rcc::{CrystalBypass, ClockSecuritySystem};
+use crate::hal::time::MilliSeconds;
+use crate::hal::watchdog::IndependentWatchdog;
+use crate::rt::ExceptionFrame;
+
+use crate::sh::hio;
+use core::fmt::Write;
+
+#[entry]
+fn main() -> ! {
+    let mut hstdout = hio::hstdout().unwrap();
+
+    writeln!(hstdout, "Hello, world!").unwrap();
+
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = hal::stm32::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
+    
+    // Try a different clock configuration
+    let clocks = rcc
+        .cfgr
+        .lse(CrystalBypass::Disable, ClockSecuritySystem::Disable)
+        .lsi(true)
+        .freeze(&mut flash.acr, &mut pwr);
+    
+    let mut timer = Delay::new(cp.SYST, clocks);
+  
+    let mut watchdog = IndependentWatchdog::new(dp.IWDG);
+    watchdog.stop_on_debug(&dp.DBGMCU, true);
+
+    watchdog.start(MilliSeconds(980));
+    timer.delay_ms(1000_u32);
+    watchdog.feed();
+    timer.delay_ms(1000_u32);
+    watchdog.feed();
+    timer.delay_ms(1000_u32);
+    watchdog.feed();
+    writeln!(hstdout, "Good bye!").unwrap();
+    loop {}
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@ pub use crate::pac as device;
 ))]
 pub use crate::pac as stm32;
 
-
 pub mod traits;
 
 #[cfg(any(
@@ -198,8 +197,17 @@ pub mod timer;
     feature = "stm32l4x6"
 ))]
 pub mod tsc;
+
 #[cfg(all(
     feature = "stm32-usbd",
     any(feature = "stm32l4x2", feature = "stm32l4x3")
 ))]
 pub mod usb;
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x3",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6"
+))]
+pub mod watchdog;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,7 +1,7 @@
 //! Time units
 
-use cortex_m::peripheral::DWT;
 use crate::rcc::Clocks;
+use cortex_m::peripheral::DWT;
 
 /// Bits per second
 #[derive(Clone, Copy, Debug)]
@@ -124,3 +124,7 @@ impl Instant {
         DWT::get_cycle_count().wrapping_sub(self.now)
     }
 }
+
+/// Time unit
+#[derive(PartialEq, PartialOrd, Clone, Copy)]
+pub struct MilliSeconds(pub u32);

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,110 @@
+//! Watchdog peripherals
+
+use crate::{
+    hal::watchdog::{Watchdog, WatchdogEnable},
+    stm32::{DBGMCU, IWDG},
+    time::MilliSeconds,
+};
+
+/// Wraps the Independent Watchdog (IWDG) peripheral
+pub struct IndependentWatchdog {
+    iwdg: IWDG,
+}
+
+const LSI_KHZ: u32 = 32;
+const MAX_PR: u8 = 0b110;
+const MAX_RL: u16 = 0xFFF;
+const KR_ACCESS: u16 = 0x5555;
+const KR_RELOAD: u16 = 0xAAAA;
+const KR_START: u16 = 0xCCCC;
+
+impl IndependentWatchdog {
+    /// Creates a new `IndependentWatchDog` without starting it. Call `start` to start the watchdog.
+    /// See `WatchdogEnable` and `Watchdog` for more info.
+    pub fn new(iwdg: IWDG) -> Self {
+        IndependentWatchdog { iwdg }
+    }
+
+    /// Debug independent watchdog stopped when core is halted
+    pub fn stop_on_debug(&self, dbgmcu: &DBGMCU, stop: bool) {
+        #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x2", feature = "stm32l4x3",))]
+        dbgmcu.apb1fzr1.modify(|_, w| w.dbg_iwdg_stop().bit(stop));
+        #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6"))]
+        dbgmcu.apb1_fzr1.modify(|_, w| w.dbg_iwdg_stop().bit(stop));
+    }
+
+    /// Sets the watchdog timer timout period. Max: 32768 ms
+    fn setup(&self, timeout_ms: u32) {
+        let mut pr = 0;
+        while pr < MAX_PR && Self::timeout_period(pr, MAX_RL) < timeout_ms {
+            pr += 1;
+        }
+
+        let max_period = Self::timeout_period(pr, MAX_RL);
+        let max_rl = u32::from(MAX_RL);
+        let rl = (timeout_ms * max_rl / max_period).min(max_rl) as u16;
+
+        self.access_registers(|iwdg| {
+            iwdg.pr.modify(|_, w| w.pr().bits(pr));
+            iwdg.rlr.modify(|_, w| w.rl().bits(rl));
+        });
+    }
+
+    fn is_pr_updating(&self) -> bool {
+        self.iwdg.sr.read().pvu().bit()
+    }
+
+    /// Returns the interval in ms
+    pub fn interval(&self) -> MilliSeconds {
+        while self.is_pr_updating() {}
+
+        let pr = self.iwdg.pr.read().pr().bits();
+        let rl = self.iwdg.rlr.read().rl().bits();
+        let ms = Self::timeout_period(pr, rl);
+        MilliSeconds(ms)
+    }
+
+    /// pr: Prescaler divider bits, rl: reload value
+    ///
+    /// Returns timeout period in ms
+    fn timeout_period(pr: u8, rl: u16) -> u32 {
+        let divider: u32 = match pr {
+            0b000 => 4,
+            0b001 => 8,
+            0b010 => 16,
+            0b011 => 32,
+            0b100 => 64,
+            0b101 => 128,
+            0b110 => 256,
+            0b111 => 256,
+            _ => unreachable!(),
+        };
+        (u32::from(rl) + 1) * divider / LSI_KHZ
+    }
+
+    fn access_registers<A, F: FnMut(&IWDG) -> A>(&self, mut f: F) -> A {
+        // Unprotect write access to registers
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_ACCESS) });
+        let a = f(&self.iwdg);
+
+        // Protect again
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_RELOAD) });
+        a
+    }
+}
+
+impl WatchdogEnable for IndependentWatchdog {
+    type Time = MilliSeconds;
+
+    fn start<T: Into<Self::Time>>(&mut self, period: T) {
+        self.setup(period.into().0);
+
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_START) });
+    }
+}
+
+impl Watchdog for IndependentWatchdog {
+    fn feed(&mut self) {
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_RELOAD) });
+    }
+}


### PR DESCRIPTION
Implementing the independent watchdog timer.
Following the examples of other hals like [`stm32f4xx`](https://github.com/stm32-rs/stm32f4xx-hal/blob/master/src/watchdog.rs).