### PR TITLE
Reexport typenum so users can access traits

### DIFF
--- a/src/dma.rs
+++ b/src/dma.rs
@@ -11,7 +11,7 @@ use core::slice;
 
 use crate::rcc::AHB1;
 use as_slice::AsSlice;
-pub use generic_array::typenum::consts;
+pub use generic_array::typenum::{self, consts};
 use generic_array::{ArrayLength, GenericArray};
 use stable_deref_trait::StableDeref;
 


### PR DESCRIPTION
It is currently so that the user needs to add `typenum` to their own crate to access the traits, with this the reexport is there if one wants to do more with the constants.