### PR TITLE
Support Nucleo serial

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -793,6 +793,12 @@ impl_pin_traits! {
             RTS_DE: PA1, PD4;
             CTS: PA0, PD3;
         }
+        AF3: {
+            TX: ;
+            RX: PA15;
+            RTS_DE: ;
+            CTS: ;
+        }
     }
 }
 


### PR DESCRIPTION
The Nucleo-32 boards have TX on PA2 and RX on PA15. This requires PA2 and PA15 to have different alternate functions (AF7 and AF3 respectively), which was not previously supported.