### PR TITLE
Fix I2C addressing

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -184,7 +184,7 @@ macro_rules! hal {
                     // START and prepare to send `bytes`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(addr as u16) // upto 9 bits for address
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .clear_bit()
                             .nbytes()
@@ -218,7 +218,7 @@ macro_rules! hal {
                     buffer: &mut [u8],) -> Result<(), Error> {
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(addr as u16)
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .set_bit()
                             .nbytes()
@@ -259,7 +259,7 @@ macro_rules! hal {
                     // START and prepare to send `bytes`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(addr as u16)
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .clear_bit()
                             .nbytes()
@@ -285,7 +285,7 @@ macro_rules! hal {
                     // reSTART and prepare to receive bytes into `buffer`
                     self.i2c.cr2.write(|w| {
                         w.sadd()
-                            .bits(addr as u16)
+                            .bits((addr as u16) << 1)
                             .rd_wrn()
                             .set_bit()
                             .nbytes()


### PR DESCRIPTION
As we only support <= 8 bits addressing, we should shift the address as per the bits 1:7 notes on page 1320. Fixes issue #93.