### PR TITLE
Implement RTC Alarms and wakeup timer, with interrupt support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6.1"
+cortex-m = "0.6.3"
 nb = "0.1.1"
 stm32l4 = "0.11.0"
 as-slice = "0.1"
@@ -63,8 +63,8 @@ unproven = ["embedded-hal/unproven"]
 [dev-dependencies]
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.0"
-cortex-m-semihosting = "0.3.1"
-cortex-m-rt = "0.6.6"
+cortex-m-semihosting = "0.3.5"
+cortex-m-rt = "0.6.12"
 usb-device = "0.2.3"
 usbd-serial = "0.1.0"
 heapless = "0.5"

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -36,27 +36,27 @@ fn main() -> ! {
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();
     let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
-    
+
     // Try a different clock configuration
     let clocks = rcc
         .cfgr
         .lse(CrystalBypass::Disable, ClockSecuritySystem::Disable)
         .freeze(&mut flash.acr, &mut pwr);
-    
+
     let mut timer = Delay::new(cp.SYST, clocks);
-  
-    let rtc = Rtc::rtc(
-        dp.RTC, 
-        &mut rcc.apb1r1, 
-        &mut rcc.bdcr, 
+
+    let mut rtc = Rtc::rtc(
+        dp.RTC,
+        &mut rcc.apb1r1,
+        &mut rcc.bdcr,
         &mut pwr.cr1,
-        RtcConfig::default().clock_config(RtcClockSource::LSE) 
+        RtcConfig::default().clock_config(RtcClockSource::LSE)
     );
 
-    let mut time = Time::new(21.hours(), 57.minutes(), 32.seconds(), 0.micros(), false);
-    let mut date = Date::new(1.day(), 24.date(), 4.month(), 2018.year());
+    let time = Time::new(21.hours(), 57.minutes(), 32.seconds(), 0.micros(), false);
+    let date = Date::new(1.day(), 24.date(), 4.month(), 2018.year());
 
-    rtc.set_time(Some(&time), Some(&date));
+    rtc.set_date_time(date, time);
 
     timer.delay_ms(1000_u32);
     timer.delay_ms(1000_u32);

--- a/examples/rtc_alarm.rs
+++ b/examples/rtc_alarm.rs
@@ -1,0 +1,102 @@
+//! Sets an RTC alarm
+
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+#[macro_use]
+extern crate cortex_m_rt as rt;
+extern crate cortex_m_semihosting as sh;
+extern crate panic_semihosting;
+extern crate stm32l4xx_hal as hal;
+
+use crate::hal::datetime::{Date, Time};
+use crate::hal::prelude::*;
+use crate::hal::rcc::{ClockSecuritySystem, CrystalBypass};
+use crate::hal::rtc::{Alarm, Event, Rtc, RtcClockSource, RtcConfig};
+use crate::rt::ExceptionFrame;
+use cortex_m::interrupt::{free, Mutex};
+
+use crate::sh::hio;
+use core::{cell::RefCell, fmt::Write, ops::DerefMut};
+use hal::interrupt;
+use hal::pac;
+use pac::NVIC;
+
+static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let mut hstdout = hio::hstdout().unwrap();
+
+    writeln!(hstdout, "Hello, world!").unwrap();
+
+    let mut dp = hal::stm32::Peripherals::take().unwrap();
+    dp.RCC.apb2enr.write(|w| w.syscfgen().set_bit());
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
+
+    // Try a different clock configuration
+    rcc.cfgr
+        .lse(CrystalBypass::Disable, ClockSecuritySystem::Disable)
+        .freeze(&mut flash.acr, &mut pwr);
+
+
+    let mut rtc = Rtc::rtc(
+        dp.RTC,
+        &mut rcc.apb1r1,
+        &mut rcc.bdcr,
+        &mut pwr.cr1,
+        RtcConfig::default().clock_config(RtcClockSource::LSE),
+    );
+
+    let time = Time::new(21.hours(), 57.minutes(), 32.seconds(), 0.micros(), false);
+    let date = Date::new(1.day(), 24.date(), 4.month(), 2018.year());
+
+    rtc.set_date_time(date, time);
+
+    // Set alarm A for 1 minute
+    // let alarm_time = Time::new(21.hours(), 57.minutes(), 37.seconds(), 0.micros(), false);
+    // let alarm_date = date;
+    // rtc.set_alarm(Alarm::AlarmA, alarm_date, alarm_time);
+    let mut wkp = rtc.wakeup_timer();
+    wkp.start(15_u32);
+    rtc.listen(&mut dp.EXTI, Event::WakeupTimer);
+
+    unsafe {
+        NVIC::unmask(pac::Interrupt::RTC_WKUP);
+    }
+
+    free(|cs| {
+        RTC.borrow(cs).replace(Some(rtc));
+    });
+
+    loop {
+
+        // nb::block!(wkp.wait()).unwrap();
+        // writeln!(hstdout, "Good bye!").unwrap();
+
+    }
+}
+
+#[interrupt]
+fn RTC_WKUP() {
+    let mut hstdout = hio::hstdout().unwrap();
+    free(|cs| {
+        let mut rtc_ref = RTC.borrow(cs).borrow_mut();
+        if let Some(ref mut rtc) = rtc_ref.deref_mut() {
+            if rtc.check_interrupt(Event::WakeupTimer) {
+                writeln!(hstdout, "RTC Wakeup!").unwrap();
+                // if we don't clear this bit, the ISR would trigger indefinitely
+                rtc.clear_interrupt_pending_bit(Event::WakeupTimer);
+            }
+        }
+    });
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}


### PR DESCRIPTION
- Bump cortex-m dependency version
- Bump cortex-m-semihosting & cortex-m-rt dev-dependency versions
- Rewrite RTC to use closure for write-protection, making it easier to read and harder to make mistakes
- Implement RTC Alarms and wakeup timer, with interrupt support
- Add RTC wakeup timer example, with hints to alarm usage as well