### PR TITLE
Some adc implementations for stm32l4x6

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -29,5 +29,5 @@ rustflags = [
 # Pick ONE of these compilation targets
 # target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
 # target = "thumbv7m-none-eabi"    # Cortex-M3
-target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-# target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,8 @@
         "**/node_modules/*/**": true
     },
     "rust-client.engine":"rust-analyzer",
-    "rust.target": "thumbv7em-none-eabi",
     "rust-analyzer.cargo.features": ["stm32l4x6"],
-    "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
+    "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
     "rust-analyzer.checkOnSave.allTargets": false,
-    "rust.all_targets": false,
     "rust.unstable_features": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{   
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/target/*/**":true,
+        "**/node_modules/*/**": true
+    },
+    "rust-client.engine":"rust-analyzer",
+    "rust.target": "thumbv7em-none-eabi",
+    "rust-analyzer.cargo.features": ["stm32l4x6"],
+    "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust.all_targets": false,
+    "rust.unstable_features": true
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,10 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6.3"
 nb = "0.1.1"
-stm32l4 = "0.11.0"
+stm32l4 = "0.12.1"
 as-slice = "0.1"
 generic-array = "0.13"
+cortex-m-semihosting = "0.3.5"
 
 [dependencies.cast]
 version  = "0.2.2"

--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -12,12 +12,12 @@ use crate::hal::{
     prelude::*,
     stm32,
 };
-use cortex_m::{
-    interrupt::{free, Mutex},
-    peripheral::NVIC
-};
 use core::cell::RefCell;
 use core::ops::DerefMut;
+use cortex_m::{
+    interrupt::{free, Mutex},
+    peripheral::NVIC,
+};
 use rt::entry;
 
 // Set up global state. It's all mutexed up for concurrency safety.
@@ -49,7 +49,9 @@ fn main() -> ! {
         board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
 
         // Enable interrupts
-        unsafe { NVIC::unmask(stm32::Interrupt::EXTI15_10); }
+        unsafe {
+            NVIC::unmask(stm32::Interrupt::EXTI15_10);
+        }
 
         free(|cs| {
             BUTTON.borrow(cs).replace(Some(board_btn));

--- a/examples/pll_config.rs
+++ b/examples/pll_config.rs
@@ -39,9 +39,9 @@ fn main() -> ! {
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(80.mhz()).pclk1(80.mhz()).pclk2(80.mhz()).freeze(&mut flash.acr);
     let plls = PllConfig {
-        m: 0b001,  // / 2
-        n: 0b1000, // * 8
-        r: PllDivider::Div8,   // /8
+        m: 0b001,            // / 2
+        n: 0b1000,           // * 8
+        r: PllDivider::Div8, // /8
     };
     // NOTE: it is up to the user to make sure the pll config matches the given sysclk
     let clocks = rcc

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -17,7 +17,7 @@ extern crate stm32l4xx_hal as hal;
 use crate::hal::datetime::{Date, Time};
 use crate::hal::delay::Delay;
 use crate::hal::prelude::*;
-use crate::hal::rcc::{CrystalBypass, ClockSecuritySystem};
+use crate::hal::rcc::{ClockSecuritySystem, CrystalBypass};
 use crate::hal::rtc::{Rtc, RtcClockSource, RtcConfig};
 use crate::rt::ExceptionFrame;
 
@@ -50,7 +50,7 @@ fn main() -> ! {
         &mut rcc.apb1r1,
         &mut rcc.bdcr,
         &mut pwr.cr1,
-        RtcConfig::default().clock_config(RtcClockSource::LSE)
+        RtcConfig::default().clock_config(RtcClockSource::LSE),
     );
 
     let time = Time::new(21.hours(), 57.minutes(), 32.seconds(), 0.micros(), false);

--- a/examples/rtc_alarm.rs
+++ b/examples/rtc_alarm.rs
@@ -43,7 +43,6 @@ fn main() -> ! {
         .lse(CrystalBypass::Disable, ClockSecuritySystem::Disable)
         .freeze(&mut flash.acr, &mut pwr);
 
-
     let mut rtc = Rtc::rtc(
         dp.RTC,
         &mut rcc.apb1r1,
@@ -77,7 +76,6 @@ fn main() -> ! {
 
         // nb::block!(wkp.wait()).unwrap();
         // writeln!(hstdout, "Good bye!").unwrap();
-
     }
 }
 

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -15,7 +15,7 @@ extern crate stm32l4xx_hal as hal;
 
 use crate::hal::delay::Delay;
 use crate::hal::prelude::*;
-use crate::hal::rcc::{CrystalBypass, ClockSecuritySystem};
+use crate::hal::rcc::{ClockSecuritySystem, CrystalBypass};
 use crate::hal::time::MilliSeconds;
 use crate::hal::watchdog::IndependentWatchdog;
 use crate::rt::ExceptionFrame;
@@ -35,23 +35,20 @@ fn main() -> ! {
     let mut flash = dp.FLASH.constrain();
     let mut rcc = dp.RCC.constrain();
     let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
-    
+
     // Try a different clock configuration
-    let clocks = rcc
-        .cfgr
-        .lsi(true)
-        .freeze(&mut flash.acr, &mut pwr);
-    
+    let clocks = rcc.cfgr.lsi(true).freeze(&mut flash.acr, &mut pwr);
+
     let mut timer = Delay::new(cp.SYST, clocks);
-  
+
     // Initiate the independent watchdog timer
     let mut watchdog = IndependentWatchdog::new(dp.IWDG);
     watchdog.stop_on_debug(&dp.DBGMCU, true);
-    
+
     // Start the independent watchdog timer
     watchdog.start(MilliSeconds(1020));
     timer.delay_ms(1000_u32);
-    
+
     // Feed the independent watchdog timer
     watchdog.feed();
     timer.delay_ms(1000_u32);

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,0 +1,104 @@
+use crate::gpio::gpioa::{PA0, PA1};
+use crate::gpio::{Analog, Floating, Input};
+use crate::rcc::AHB2;
+use core::marker::PhantomData;
+use embedded_hal::adc::{Channel, OneShot};
+
+#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+use stm32l4::stm32l4x2::{
+    rcc::CCIPR,
+    ADC
+};
+
+#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+pub struct Adc<ADC> {
+    adc: ADC,
+}
+
+#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+impl Adc<crate::device::ADC> {
+    pub fn adc1(adc: crate::device::ADC, ahb2: &mut AHB2) -> Self {
+        // Select system clock as clock for ADC
+        let rcc = unsafe { &*crate::device::RCC::ptr() };
+        rcc.ccipr.modify(|r, w| unsafe { w.adcsel().bits(0b11) });
+        //        common.ccr.modify(|r, w| unsafe { w.ckmode().bits(0b11) });
+        //        common.ccr.modify(|r, w| unsafe { w.presc().bits(0b1011) });
+        ahb2.enr().modify(|r, w| w.adcen().set_bit());
+        //        common.ccr.modify(|r, w| w.vrefen().set_bit());
+
+        // Disable deep power down and start ADC voltage regulator
+        adc.cr.modify(|r, w| w.deeppwd().clear_bit());
+        adc.cr.modify(|r, w| w.advregen().set_bit());
+        cortex_m::asm::delay(8_000_000);
+
+        // Calibrate
+        adc.cr.modify(|r, w| w.adcaldif().clear_bit());
+        adc.cr.modify(|r, w| w.adcal().set_bit());
+
+        while adc.cr.read().adcal().bit_is_set() {}
+
+        Self { adc }
+    }
+
+    pub fn power_up(&mut self) {
+        self.adc.isr.modify(|_, w| w.adrdy().set_bit());
+        self.adc.cr.modify(|_, w| w.aden().set_bit());
+        while self.adc.isr.read().adrdy().bit_is_clear() {}
+    }
+
+    pub fn power_down(&mut self) {
+        self.adc.cr.modify(|_, w| w.addis().set_bit());
+        self.adc.isr.modify(|_, w| w.adrdy().set_bit());
+        while self.adc.cr.read().aden().bit_is_set() {}
+    }
+}
+
+#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+impl Channel<Adc<crate::device::ADC>> for PA0<Analog> {
+    type ID = u8;
+
+    fn channel() -> u8 {
+        5
+    }
+}
+
+#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+impl Channel<Adc<crate::device::ADC>> for PA1<Analog> {
+    type ID = u8;
+
+    fn channel() -> u8 {
+        6
+    }
+}
+
+#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+impl<WORD, PIN> OneShot<Adc<crate::device::ADC>, WORD, PIN> for Adc<crate::stm32::ADC>
+where
+    WORD: From<u16>,
+    PIN: Channel<Adc<crate::device::ADC>, ID = u8>,
+{
+    type Error = ();
+
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        self.power_up();
+        self.adc.cfgr.modify(|r, w| unsafe { w.exten().bits(0b00) });
+        self.adc
+            .cfgr
+            .modify(|r, w| unsafe { w.align().clear_bit().res().bits(0b00).cont().clear_bit() });
+        self.adc
+            .sqr1
+            .modify(|r, w| unsafe { w.sq1().bits(PIN::channel()) });
+        self.adc
+            .cfgr2
+            .modify(|r, w| unsafe { w.rovse().set_bit().ovsr().bits(0b011) });
+        self.adc.isr.modify(|r, w| w.eoc().set_bit());
+        self.adc.cr.modify(|r, w| w.adstart().set_bit());
+
+        //        cortex_m::asm::delay(80_000_000);
+        while self.adc.isr.read().eoc().bit_is_clear() {}
+
+        let val = self.adc.dr.read().regular_data().bits().into();
+        self.power_down();
+        Ok(val)
+    }
+}

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,11 +1,10 @@
 use crate::gpio::gpioa;
-use crate::gpio::gpioc;
 use crate::gpio::gpiob;
+use crate::gpio::gpioc;
 use crate::gpio::Analog;
+use crate::pac::ADC1;
 use crate::rcc::{AHB2, CCIPR};
 use embedded_hal::adc::{Channel, OneShot};
-use crate::pac::{ADC1};
-
 
 /// Inspiration has been drawn from three different ADC libs
 /// https://github.com/stm32-rs/stm32l1xx-hal/blob/master/src/adc.rs
@@ -29,68 +28,64 @@ pub enum Align {
     Left,
 }
 
-
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
-pub enum RegularOversampling{
+pub enum RegularOversampling {
     On = 0b1,
-    Off = 0b0
+    Off = 0b0,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
-pub enum InjectedOversampling{
+pub enum InjectedOversampling {
     On = 0b1,
-    Off = 0b0
+    Off = 0b0,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u16)]
-pub enum OversamplingRatio{
-   /// 2x ADC Oversampling ratio
-   X2 = 0b000,
-   /// 4x ADC Oversampling ratio
-   X4 = 0b001,
-   /// 8x ADC Oversampling ratio
-   X8 = 0b010,
-   /// 16x ADC Oversampling ratio
-   X16 = 0b011,
-   /// 32x ADC Oversampling ratio
-   X32 = 0b100,
-   /// 64x ADC Oversampling ratio
-   X64 = 0b101,
-   /// 128x ADC Oversampling ratio
-   X128 = 0b110,
-   /// 256x ADC Oversampling ratio
-   X256 = 0b111,
+pub enum OversamplingRatio {
+    /// 2x ADC Oversampling ratio
+    X2 = 0b000,
+    /// 4x ADC Oversampling ratio
+    X4 = 0b001,
+    /// 8x ADC Oversampling ratio
+    X8 = 0b010,
+    /// 16x ADC Oversampling ratio
+    X16 = 0b011,
+    /// 32x ADC Oversampling ratio
+    X32 = 0b100,
+    /// 64x ADC Oversampling ratio
+    X64 = 0b101,
+    /// 128x ADC Oversampling ratio
+    X128 = 0b110,
+    /// 256x ADC Oversampling ratio
+    X256 = 0b111,
 }
-
 
 ///
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u16)]
-pub enum OversamplingShift{
+pub enum OversamplingShift {
     /// 0 bit Oversampling shift. Same as divide by 0
-   S0 = 0b0000,
-   /// 1 bits Oversampling shift. Same as divide by 2
-   S1 = 0b0001,
-   /// 2 bits Oversampling shift. Same as divide by 4
-   S2 = 0b0010,
-   /// 3 bits Oversampling shift. Same as divide by 8
-   S3 = 0b0011,
-   /// 4 bits Oversampling shift. Same as divide by 16
-   S4 = 0b0100,
-   /// 5 bits Oversampling shift. Same as divide by 32
-   S5 = 0b0101,
-   /// 6 bits Oversampling shift. Same as divide by 64
-   S6 = 0b0110,
-   /// 7 bits Oversampling shift. Same as divide by 128
-   S7 = 0b0111,
-   /// 8 bits Oversampling shift. Same as divide by 256
-   S8 = 0b1000,
+    S0 = 0b0000,
+    /// 1 bits Oversampling shift. Same as divide by 2
+    S1 = 0b0001,
+    /// 2 bits Oversampling shift. Same as divide by 4
+    S2 = 0b0010,
+    /// 3 bits Oversampling shift. Same as divide by 8
+    S3 = 0b0011,
+    /// 4 bits Oversampling shift. Same as divide by 16
+    S4 = 0b0100,
+    /// 5 bits Oversampling shift. Same as divide by 32
+    S5 = 0b0101,
+    /// 6 bits Oversampling shift. Same as divide by 64
+    S6 = 0b0110,
+    /// 7 bits Oversampling shift. Same as divide by 128
+    S7 = 0b0111,
+    /// 8 bits Oversampling shift. Same as divide by 256
+    S8 = 0b1000,
 }
-
-
 
 /// ADC Sampling Resolution
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -133,10 +128,10 @@ pub struct Config {
     pub align: Align,
     pub resolution: Resolution,
     pub sample_time: SampleTime,
-    pub reg_oversampl : RegularOversampling,
-    pub inj_oversampl : InjectedOversampling,
-    pub oversampl_ratio : OversamplingRatio,
-    pub oversampl_shift : OversamplingShift,
+    pub reg_oversampl: RegularOversampling,
+    pub inj_oversampl: InjectedOversampling,
+    pub oversampl_ratio: OversamplingRatio,
+    pub oversampl_shift: OversamplingShift,
 }
 
 impl Config {
@@ -145,7 +140,7 @@ impl Config {
         self
     }
 
-    pub fn resolution(mut self, resolution : Resolution) -> Self {
+    pub fn resolution(mut self, resolution: Resolution) -> Self {
         self.resolution = resolution;
         self
     }
@@ -154,19 +149,19 @@ impl Config {
         self.sample_time = sample_time;
         self
     }
-    pub fn reg_oversampl(mut self, reg_oversampl: RegularOversampling) -> Self{
+    pub fn reg_oversampl(mut self, reg_oversampl: RegularOversampling) -> Self {
         self.reg_oversampl = reg_oversampl;
         self
     }
-    pub fn inj_oversampl(mut self, inj_oversampl: InjectedOversampling) -> Self{
+    pub fn inj_oversampl(mut self, inj_oversampl: InjectedOversampling) -> Self {
         self.inj_oversampl = inj_oversampl;
         self
     }
-    pub fn oversampl_ratio(mut self, oversampl_ratio: OversamplingRatio) -> Self{
+    pub fn oversampl_ratio(mut self, oversampl_ratio: OversamplingRatio) -> Self {
         self.oversampl_ratio = oversampl_ratio;
         self
     }
-    pub fn oversampl_shift(mut self, oversampl_shift: OversamplingShift) -> Self{
+    pub fn oversampl_shift(mut self, oversampl_shift: OversamplingShift) -> Self {
         self.oversampl_shift = oversampl_shift;
         self
     }
@@ -175,13 +170,13 @@ impl Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            align : Align::Right,
+            align: Align::Right,
             resolution: Resolution::B12,
             sample_time: SampleTime::T12_5,
-            reg_oversampl : RegularOversampling::Off,
-            inj_oversampl : InjectedOversampling::Off,
-            oversampl_ratio : OversamplingRatio::X16,
-            oversampl_shift : OversamplingShift::S4,
+            reg_oversampl: RegularOversampling::Off,
+            inj_oversampl: InjectedOversampling::Off,
+            oversampl_ratio: OversamplingRatio::X16,
+            oversampl_shift: OversamplingShift::S4,
         }
     }
 }
@@ -191,7 +186,7 @@ pub enum ClockMode {
     /// Makes use of the ADC select from RCC (Asynchronous clock mode),
     /// generated at product level (refer to Section 6: Reset and clock control (RCC))
     CkAdc = 0b00,
-    /// HCLK/1 (Synchronous clock mode). 
+    /// HCLK/1 (Synchronous clock mode).
     /// This configuration must be enabled only if the AHB
     /// clock prescaler is set to 1 (HPRE[3:0] = 0xxx in RCC_CFGR register) and if the system clock
     HclkDiv1 = 0b01,
@@ -200,7 +195,6 @@ pub enum ClockMode {
     /// 6 bit Resolution
     HclkDiv4 = 0b11,
 }
-
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
@@ -217,8 +211,8 @@ pub enum AdcClockSelect {
 
 #[derive(Copy, Clone, PartialEq)]
 pub struct CommonConfig {
-    pub clock_mode : ClockMode,
-    pub adc_clk_sel : AdcClockSelect,
+    pub clock_mode: ClockMode,
+    pub adc_clk_sel: AdcClockSelect,
 }
 
 impl CommonConfig {
@@ -236,82 +230,81 @@ impl CommonConfig {
 impl Default for CommonConfig {
     fn default() -> CommonConfig {
         CommonConfig {
-            clock_mode : ClockMode::HclkDiv2,
-            adc_clk_sel : AdcClockSelect::Pllsai1,
+            clock_mode: ClockMode::HclkDiv2,
+            adc_clk_sel: AdcClockSelect::Pllsai1,
         }
     }
 }
 
 /// Global setup for ADC
-pub fn adc_global_setup(config : CommonConfig, ahb2 : &mut AHB2, ccipr : &mut CCIPR) {
-
+pub fn adc_global_setup(config: CommonConfig, ahb2: &mut AHB2, ccipr: &mut CCIPR) {
     // Setup Rcc clock select
-    ccipr.ccipr().modify(|_, w|unsafe { w.adcsel().bits(config.adc_clk_sel as u8) } );  
-    
+    ccipr
+        .ccipr()
+        .modify(|_, w| unsafe { w.adcsel().bits(config.adc_clk_sel as u8) });
+
     // Enable clock for ADC
     ahb2.enr().modify(|_r, w| w.adcen().set_bit());
-    
+
     // Set ADC common clock
     // The software is allowed to write these bits only when the ADCs are disabled
-    //  (ADCAL=0, JADSTART=0, ADSTART=0, ADSTP=0, ADDIS=0 and ADEN=0) in all adc_cr registers.    
+    //  (ADCAL=0, JADSTART=0, ADSTART=0, ADSTP=0, ADDIS=0 and ADEN=0) in all adc_cr registers.
     let adc_common = unsafe { &*crate::device::ADC_COMMON::ptr() };
     if !any_adc_active() {
-        adc_common.ccr.modify(|_, w| unsafe {w.ckmode().bits(config.clock_mode as u8)} );
+        adc_common
+            .ccr
+            .modify(|_, w| unsafe { w.ckmode().bits(config.clock_mode as u8) });
     }
-
 }
 
 /// Checks if any ADCs are enabled or running
-fn any_adc_active() -> bool{
+fn any_adc_active() -> bool {
     let adc1 = unsafe { &*crate::device::ADC1::ptr() };
     let adc2 = unsafe { &*crate::device::ADC2::ptr() };
     let adc3 = unsafe { &*crate::device::ADC3::ptr() };
-    adc1.cr.read().adcal().bit_is_set()       |
-        adc1.cr.read().adstp().bit_is_set()     |
-        adc1.cr.read().jadstart().bit_is_set()  |
-        adc1.cr.read().adstart().bit_is_set()   |
-        adc1.cr.read().addis().bit_is_set()     |
-        adc1.cr.read().aden().bit_is_set()      |
-        adc2.cr.read().adcal().bit_is_set()   |
-        adc2.cr.read().adstp().bit_is_set()     |
-        adc2.cr.read().jadstart().bit_is_set()  |
-        adc2.cr.read().adstart().bit_is_set()   |
-        adc2.cr.read().addis().bit_is_set()     |
-        adc2.cr.read().aden().bit_is_set()      |
-        adc3.cr.read().adcal().bit_is_set()   |
-        adc3.cr.read().adstp().bit_is_set()     |
-        adc3.cr.read().jadstart().bit_is_set()  |
-        adc3.cr.read().adstart().bit_is_set()   |
-        adc3.cr.read().addis().bit_is_set()     |
-        adc3.cr.read().aden().bit_is_set() 
+    adc1.cr.read().adcal().bit_is_set()
+        | adc1.cr.read().adstp().bit_is_set()
+        | adc1.cr.read().jadstart().bit_is_set()
+        | adc1.cr.read().adstart().bit_is_set()
+        | adc1.cr.read().addis().bit_is_set()
+        | adc1.cr.read().aden().bit_is_set()
+        | adc2.cr.read().adcal().bit_is_set()
+        | adc2.cr.read().adstp().bit_is_set()
+        | adc2.cr.read().jadstart().bit_is_set()
+        | adc2.cr.read().adstart().bit_is_set()
+        | adc2.cr.read().addis().bit_is_set()
+        | adc2.cr.read().aden().bit_is_set()
+        | adc3.cr.read().adcal().bit_is_set()
+        | adc3.cr.read().adstp().bit_is_set()
+        | adc3.cr.read().jadstart().bit_is_set()
+        | adc3.cr.read().adstart().bit_is_set()
+        | adc3.cr.read().addis().bit_is_set()
+        | adc3.cr.read().aden().bit_is_set()
 }
-
 
 pub struct Adc<ADC1> {
     adc: ADC1,
-    config : Config,
+    config: Config,
 }
 
 #[cfg(feature = "stm32l4x6")]
 impl Adc<ADC1> {
     /// Sets up the ADC
-    pub fn adc1(adc: ADC1, config : Config, ahb2 : &mut AHB2, ccipr : &mut CCIPR) -> Self {
-
+    pub fn adc1(adc: ADC1, config: Config, ahb2: &mut AHB2, ccipr: &mut CCIPR) -> Self {
         // Check if it is already enabled
-        if ahb2.enr().read().adcen().bit_is_clear(){
+        if ahb2.enr().read().adcen().bit_is_clear() {
             // Only single ended mode availible
             unsafe {
-                adc.difsel.write(|w|{w.bits(0)});
+                adc.difsel.write(|w| w.bits(0));
             }
             adc_global_setup(CommonConfig::default(), ahb2, ccipr);
         }
 
-        
         // Disable deep power down and start ADC voltage regulator
         adc.cr.modify(|_, w| w.deeppwd().clear_bit());
         adc.cr.modify(|_, w| w.advregen().set_bit());
         cortex_m::asm::delay(8_000_000); //Delay at 80MHz for L475
-        if adc.cr.read().advregen().bit_is_clear(){
+        if adc.cr.read().advregen().bit_is_clear() {
             panic!("ADC Vreg not enabled corectly")
         }
 
@@ -322,7 +315,7 @@ impl Adc<ADC1> {
         while adc.cr.read().adcal().bit_is_set() {}
 
         let temp_c = Config::default();
-        let mut adc = Self{
+        let mut adc = Self {
             adc,
             config: temp_c,
         };
@@ -343,7 +336,7 @@ impl Adc<ADC1> {
     }
 
     /// Apply a configuration to the ADC
-    pub fn apply_config(&mut self, config : Config){
+    pub fn apply_config(&mut self, config: Config) {
         self.set_align(config.align);
         self.set_injected_oversampling(config.inj_oversampl);
         self.set_oversampling_ratio(config.oversampl_ratio);
@@ -357,46 +350,53 @@ impl Adc<ADC1> {
     /// a stored config.
     pub fn default_config(&mut self) -> Config {
         let cfg = self.get_config();
-        if !(cfg == Config::default()){
+        if !(cfg == Config::default()) {
             self.apply_config(Config::default());
         }
         cfg
     }
 
     /// Returns a copy of the current configuration
-    pub fn get_config(&mut self) -> Config{
+    pub fn get_config(&mut self) -> Config {
         self.config
     }
 
-
-
     pub fn set_align(&mut self, align: Align) {
-        self.adc.cfgr.modify(|_, w| w.align().bit(align == Align::Left))
+        self.adc
+            .cfgr
+            .modify(|_, w| w.align().bit(align == Align::Left))
     }
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
-        self.adc.cfgr.modify(|_, w| unsafe {w.res().bits(resolution as u8)})
+        self.adc
+            .cfgr
+            .modify(|_, w| unsafe { w.res().bits(resolution as u8) })
     }
 
-    pub fn set_regular_oversampling(&mut self, reg_oversampl : RegularOversampling){
-        self.adc.cfgr2.modify(|_, w| w.rovse().bit(reg_oversampl == RegularOversampling::On))
+    pub fn set_regular_oversampling(&mut self, reg_oversampl: RegularOversampling) {
+        self.adc
+            .cfgr2
+            .modify(|_, w| w.rovse().bit(reg_oversampl == RegularOversampling::On))
     }
 
-    pub fn set_injected_oversampling(&mut self, inj_oversampl : InjectedOversampling){
-        self.adc.cfgr2.modify(|_, w| w.jovse().bit(inj_oversampl == InjectedOversampling::On))
+    pub fn set_injected_oversampling(&mut self, inj_oversampl: InjectedOversampling) {
+        self.adc
+            .cfgr2
+            .modify(|_, w| w.jovse().bit(inj_oversampl == InjectedOversampling::On))
     }
 
-    pub fn set_oversampling_ratio(&mut self, oversampl_ratio : OversamplingRatio){
-        self.adc.cfgr2.modify(|_, w| unsafe{ w.ovsr().bits(oversampl_ratio as u8)})
+    pub fn set_oversampling_ratio(&mut self, oversampl_ratio: OversamplingRatio) {
+        self.adc
+            .cfgr2
+            .modify(|_, w| unsafe { w.ovsr().bits(oversampl_ratio as u8) })
     }
 
-    pub fn set_oversampling_shift(&mut self, oversampl_shift : OversamplingShift){
-        self.adc.cfgr2.modify(|_, w| unsafe{ w.ovss().bits(oversampl_shift as u8)})
+    pub fn set_oversampling_shift(&mut self, oversampl_shift: OversamplingShift) {
+        self.adc
+            .cfgr2
+            .modify(|_, w| unsafe { w.ovss().bits(oversampl_shift as u8) })
     }
-
 }
-
-
 
 #[cfg(feature = "stm32l4x6")]
 impl<WORD, PIN> OneShot<Adc<ADC1>, WORD, PIN> for Adc<ADC1>
@@ -418,22 +418,13 @@ where
 
         pin.setup(&mut self.adc, self.config.sample_time);
 
-        self.adc
-            .cfgr
-            .modify(|_, w| w.cont().clear_bit());
-        self.adc
-            .cfgr
-            .modify(|_, w| w.discen().clear_bit());
-        self.adc
-            .cfgr
-            .modify(|_, w| unsafe { w.exten().bits(0b00) });
+        self.adc.cfgr.modify(|_, w| w.cont().clear_bit());
+        self.adc.cfgr.modify(|_, w| w.discen().clear_bit());
+        self.adc.cfgr.modify(|_, w| unsafe { w.exten().bits(0b00) });
         self.adc
             .sqr1
             .modify(|_, w| unsafe { w.sq1().bits(PIN::channel()) });
-        self.adc
-            .sqr1
-            .modify(|_, w| unsafe { w.l().bits(0b0000)});
-
+        self.adc.sqr1.modify(|_, w| unsafe { w.l().bits(0b0000) });
 
         self.adc.isr.modify(|_, w| w.eoc().clear_bit());
         // Start conversion
@@ -448,24 +439,15 @@ where
         self.power_down();
 
         //Restore state
-        self.adc
-            .cfgr
-            .modify(|_, w| w.cont().bit(cont_mode));
+        self.adc.cfgr.modify(|_, w| w.cont().bit(cont_mode));
         self.adc
             .cfgr
             .modify(|_, w| unsafe { w.exten().bits(external_trig) });
-        self.adc
-            .sqr1
-            .modify(|_, w| unsafe { w.sq1().bits(seq_1) });
-        self.adc
-            .sqr1
-            .modify(|_, w| unsafe { w.l().bits(seq_len)});
+        self.adc.sqr1.modify(|_, w| unsafe { w.sq1().bits(seq_1) });
+        self.adc.sqr1.modify(|_, w| unsafe { w.l().bits(seq_len) });
         Ok(val)
     }
-    
 }
-
-
 
 macro_rules! int_adc {
     ($($Chan:ident: ($chan:expr, $en:ident)),+ $(,)*) => {
@@ -502,9 +484,8 @@ int_adc! {
     VBat: (18, ch18sel)
 }
 
-
 pub trait AdcChannel<T> {
-    fn setup(&mut self, adc: &mut T, sample_time : SampleTime);
+    fn setup(&mut self, adc: &mut T, sample_time: SampleTime);
 }
 
 macro_rules! adc_pins {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,99 +1,622 @@
-use crate::gpio::gpioa::{PA0, PA1};
+use crate::gpio::gpioa;
 use crate::gpio::{Analog};
-use crate::rcc::AHB2;
-//use core::marker::PhantomData;
+use crate::rcc::{AHB2,CCIPR};
 use embedded_hal::adc::{Channel, OneShot};
+use crate::pac::ADC1;
+use core::ptr;
+
+const VREFCAL: *const u16 = 0x1FFF_75AA as *const u16;
+const VTEMPCAL30: *const u16 = 0x1FFF_75A8 as *const u16;
+const VTEMPCAL110: *const u16 = 0x1FFF_75CA as *const u16;
+const VDD_CALIB: u16 = 3000;
 
 
-#[cfg(feature = "stm32l4x6")]
+/// Inspiration has been drawn from three different ADC libs
+/// https://github.com/stm32-rs/stm32l1xx-hal/blob/master/src/adc.rs
+/// https://github.com/stm32-rs/stm32f0xx-hal/blob/master/src/adc.rs
+/// https://github.com/stm32-rs/stm32f4xx-hal/blob/master/src/adc.rs
+
+/// ADC Result Alignment
+#[derive(Copy, Clone, PartialEq)]
+// #[repr(bool)]
+pub enum Align {
+    /// Right aligned results (least significant bits)
+    ///
+    /// Results in all Resolutions returning values from 0-(2^bits-1) in
+    /// steps of 1.
+    Right,
+    /// Left aligned results (most significant bits)
+    ///
+    /// Results in all Resolutions returning a value in the range 0-65535.
+    /// Depending on the Resolution the result will step by larger or smaller
+    /// amounts.
+    Left,
+}
+
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum RegularOversampling{
+    On = 0b1,
+    Off = 0b0
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum InjectedOversampling{
+    On = 0b1,
+    Off = 0b0
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u16)]
+pub enum OversamplingRatio{
+   /// 2x ADC Oversampling ratio
+   X2 = 0b000,
+   /// 4x ADC Oversampling ratio
+   X4 = 0b001,
+   /// 8x ADC Oversampling ratio
+   X8 = 0b010,
+   /// 16x ADC Oversampling ratio
+   X16 = 0b011,
+   /// 32x ADC Oversampling ratio
+   X32 = 0b100,
+   /// 64x ADC Oversampling ratio
+   X64 = 0b101,
+   /// 128x ADC Oversampling ratio
+   X128 = 0b110,
+   /// 256x ADC Oversampling ratio
+   X256 = 0b111,
+}
+
+
+///
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u16)]
+pub enum OversamplingShift{
+    /// 0 bit Oversampling shift. Same as divide by 0
+   S0 = 0b0000,
+   /// 1 bits Oversampling shift. Same as divide by 2
+   S1 = 0b0001,
+   /// 2 bits Oversampling shift. Same as divide by 4
+   S2 = 0b0010,
+   /// 3 bits Oversampling shift. Same as divide by 8
+   S3 = 0b0011,
+   /// 4 bits Oversampling shift. Same as divide by 16
+   S4 = 0b0100,
+   /// 5 bits Oversampling shift. Same as divide by 32
+   S5 = 0b0101,
+   /// 6 bits Oversampling shift. Same as divide by 64
+   S6 = 0b0110,
+   /// 7 bits Oversampling shift. Same as divide by 128
+   S7 = 0b0111,
+   /// 8 bits Oversampling shift. Same as divide by 256
+   S8 = 0b1000,
+}
+
+
+
+/// ADC Sampling Resolution
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum Resolution {
+    /// 12 bit Resolution
+    B12 = 0b00,
+    /// 10 bit Resolution
+    B10 = 0b01,
+    /// 8 bit Resolution
+    B8 = 0b10,
+    /// 6 bit Resolution
+    B6 = 0b11,
+}
+
+/// ADC Sampling time
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u16)]
+pub enum SampleTime {
+    /// 2.5 ADC clock cycles
+    T2_5 = 0b000,
+    /// 6.5 ADC clock cycles
+    T6_5 = 0b001,
+    /// 12.5 ADC clock cycles
+    T12_5 = 0b010,
+    /// 24.5 ADC clock cycles
+    T24_5 = 0b011,
+    /// 47.5 ADC clock cycles
+    T47_5 = 0b100,
+    /// 92.5 ADC clock cycles
+    T92_5 = 0b101,
+    /// 247.5 ADC clock cycles
+    T247_5 = 0b110,
+    /// 640.5 ADC clock cycles
+    T640_5 = 0b111,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub struct Config {
+    pub align: Align,
+    pub resolution: Resolution,
+    pub sample_time: SampleTime,
+    pub reg_oversampl : RegularOversampling,
+    pub inj_oversampl : InjectedOversampling,
+    pub oversampl_ratio : OversamplingRatio,
+    pub oversampl_shift : OversamplingShift,
+}
+
+impl Config {
+    pub fn align(mut self, align: Align) -> Self {
+        self.align = align;
+        self
+    }
+
+    pub fn resolution(mut self, resolution : Resolution) -> Self {
+        self.resolution = resolution;
+        self
+    }
+
+    pub fn sample_time(mut self, sample_time: SampleTime) -> Self {
+        self.sample_time = sample_time;
+        self
+    }
+    pub fn reg_oversampl(mut self, reg_oversampl: RegularOversampling) -> Self{
+        self.reg_oversampl = reg_oversampl;
+        self
+    }
+    pub fn inj_oversampl(mut self, inj_oversampl: InjectedOversampling) -> Self{
+        self.inj_oversampl = inj_oversampl;
+        self
+    }
+    pub fn oversampl_ratio(mut self, oversampl_ratio: OversamplingRatio) -> Self{
+        self.oversampl_ratio = oversampl_ratio;
+        self
+    }
+    pub fn oversampl_shift(mut self, oversampl_shift: OversamplingShift) -> Self{
+        self.oversampl_shift = oversampl_shift;
+        self
+    }
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            resolution: Resolution::B12,
+            align : Align::Right,
+            sample_time: SampleTime::T640_5,
+            reg_oversampl : RegularOversampling::Off,
+            inj_oversampl : InjectedOversampling::Off,
+            oversampl_ratio : OversamplingRatio::X16,
+            oversampl_shift : OversamplingShift::S4,
+        }
+    }
+}
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum ClockMode {
+    /// Makes use of the ADC select from RCC (Asynchronous clock mode),
+    /// generated at product level (refer to Section 6: Reset and clock control (RCC))
+    CkAdc = 0b00,
+    /// HCLK/1 (Synchronous clock mode). 
+    /// This configuration must be enabled only if the AHB
+    /// clock prescaler is set to 1 (HPRE[3:0] = 0xxx in RCC_CFGR register) and if the system clock
+    HclkDiv1 = 0b01,
+    /// 8 bit Resolution
+    HclkDiv2 = 0b10,
+    /// 6 bit Resolution
+    HclkDiv4 = 0b11,
+}
+
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum AdcClockSelect {
+    /// No clock selected
+    NoClock = 0b00,
+    /// PLLSAI1 “R” clock (PLLADC1CLK) selected as ADCs clock
+    Pllsai1 = 0b01,
+    /// PLLSAI2 “R” clock (PLLADC2CLK) selected as ADCs clock
+    Pllsai2 = 0b10,
+    /// System clock selected as ADCs clock
+    SysClk = 0b11,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub struct CommonConfig {
+    pub clock_mode : ClockMode,
+    pub adc_clk_sel : AdcClockSelect,
+}
+
+impl CommonConfig {
+    pub fn clock_mode(mut self, clock_mode: ClockMode) -> Self {
+        self.clock_mode = clock_mode;
+        self
+    }
+
+    pub fn adc_clk_sel(mut self, adc_clk_sel: AdcClockSelect) -> Self {
+        self.adc_clk_sel = adc_clk_sel;
+        self
+    }
+}
+
+impl Default for CommonConfig {
+    fn default() -> CommonConfig {
+        CommonConfig {
+            clock_mode : ClockMode::HclkDiv1,
+            adc_clk_sel : AdcClockSelect::Pllsai1,
+        }
+    }
+}
+
+/// Global setup for ADC
+pub fn adc_global_setup(config : CommonConfig, ahb2 : &mut AHB2, ccipr : &mut CCIPR) {
+
+    // Setup Rcc clock select
+    ccipr.ccipr().modify(|_, w|unsafe { w.adcsel().bits(config.adc_clk_sel as u8) } );  
+    
+    // Enable clock for ADC
+    ahb2.enr().modify(|_r, w| w.adcen().set_bit());
+    
+    // Set ADC common clock
+    // The software is allowed to write these bits only when the ADCs are disabled
+    //  (ADCAL=0, JADSTART=0, ADSTART=0, ADSTP=0, ADDIS=0 and ADEN=0) in all adc_cr registers.    
+    let adc_common = unsafe { &*crate::device::ADC_COMMON::ptr() };
+    if !any_adc_active() {
+        adc_common.ccr.modify(|_, w| unsafe {w.ckmode().bits(config.clock_mode as u8)} );
+    }
+
+    // Not possible yet, due to missing register
+    //        adc_common.ccr.modify(|_, w| unsafe { w.presc().bits(0b1011) });
+}
+
+/// Checks if any ADCs are enabled or running
+fn any_adc_active() -> bool{
+    let adc1 = unsafe { &*crate::device::ADC1::ptr() };
+    adc1.cr.read().adcal().bit_is_set()       |
+        adc1.cr.read().adstp().bit_is_set()     |
+        adc1.cr.read().jadstart().bit_is_set()  |
+        adc1.cr.read().adstart().bit_is_set()   |
+        adc1.cr.read().addis().bit_is_set()     |
+        adc1.cr.read().aden().bit_is_set()      
+}
+
+
 pub struct Adc<ADC1> {
     adc: ADC1,
+    config : Config,
 }
 
 #[cfg(feature = "stm32l4x6")]
-impl Adc<crate::device::ADC1> {
-    pub fn adc1(adc: crate::device::ADC1, ahb2: &mut AHB2) -> Self {
-        // Select system clock as clock for ADC
-        let rcc = unsafe { &*crate::device::RCC::ptr() };
-        rcc.ccipr.modify(|_, w| unsafe { w.adcsel().bits(0b11) });
-        //        common.ccr.modify(|r, w| unsafe { w.ckmode().bits(0b11) });
-        //        common.ccr.modify(|r, w| unsafe { w.presc().bits(0b1011) });
-        ahb2.enr().modify(|_, w| w.adcen().set_bit());
-        //        common.ccr.modify(|r, w| w.vrefen().set_bit());
+impl Adc<ADC1> {
+    /// Sets up the ADC
+    pub fn adc1(adc: ADC1, config : Config, ahb2 : &mut AHB2, ccipr : &mut CCIPR) -> Self {
+        
+
+
+        //Check these two registers for 0
+        if ahb2.enr().read().adcen().bit_is_clear(){
+            adc_global_setup(CommonConfig::default(), ahb2, ccipr);
+        }
 
         // Disable deep power down and start ADC voltage regulator
         adc.cr.modify(|_, w| w.deeppwd().clear_bit());
         adc.cr.modify(|_, w| w.advregen().set_bit());
-        // cortex_m::asm::delay(8_000_000);
+        cortex_m::asm::delay(8_000_000); //Delay at 80MHz for L475
+        if adc.cr.read().advregen().bit_is_clear(){
+            panic!("ADC Vreg not enabled corectly")
+        }
 
         // Calibrate
+        adc.cfgr.modify(|_, w| w.dmaen().clear_bit());
         adc.cr.modify(|_, w| w.adcaldif().clear_bit());
         adc.cr.modify(|_, w| w.adcal().set_bit());
-
         while adc.cr.read().adcal().bit_is_set() {}
 
-        Self { adc }
+        let temp_c = Config::default();
+        let mut adc = Self{
+            adc,
+            config: temp_c,
+        };
+        adc.apply_config(config);
+        adc
     }
 
-    pub fn power_up(&mut self) {
+    fn power_up(&mut self) {
         self.adc.isr.modify(|_, w| w.adrdy().set_bit());
         self.adc.cr.modify(|_, w| w.aden().set_bit());
         while self.adc.isr.read().adrdy().bit_is_clear() {}
     }
 
-    pub fn power_down(&mut self) {
+    fn power_down(&mut self) {
         self.adc.cr.modify(|_, w| w.addis().set_bit());
         self.adc.isr.modify(|_, w| w.adrdy().set_bit());
         while self.adc.cr.read().aden().bit_is_set() {}
     }
-}
 
-#[cfg(feature = "stm32l4x6")]
-impl Channel<Adc<crate::device::ADC1>> for PA0<Analog> {
-    type ID = u8;
-
-    fn channel() -> u8 {
-        5
+    /// Apply a configuration to the ADC
+    pub fn apply_config(&mut self, config : Config){
+        self.set_align(config.align);
+        self.set_injected_oversampling(config.inj_oversampl);
+        self.set_oversampling_ratio(config.oversampl_ratio);
+        self.set_oversampling_shift(config.oversampl_shift);
+        self.set_regular_oversampling(config.reg_oversampl);
+        self.set_resolution(config.resolution);
+        self.config = config;
     }
-}
 
-#[cfg(feature = "stm32l4x6")]
-impl Channel<Adc<crate::device::ADC1>> for PA1<Analog> {
-    type ID = u8;
-
-    fn channel() -> u8 {
-        6
+    /// Resets the ADC config to default, returning the existing config as
+    /// a stored config.
+    pub fn default_config(&mut self) -> Config {
+        let cfg = self.get_config();
+        if !(cfg == Config::default()){
+            self.apply_config(Config::default());
+        }
+        cfg
     }
+
+    /// Returns a copy of the current configuration
+    pub fn get_config(&mut self) -> Config{
+        self.config
+    }
+
+
+
+    pub fn set_align(&mut self, align: Align) {
+        self.adc.cfgr.modify(|_, w| w.align().bit(align == Align::Left))
+    }
+
+    pub fn set_resolution(&mut self, resolution: Resolution) {
+        self.adc.cfgr.modify(|_, w| unsafe {w.res().bits(resolution as u8)})
+    }
+
+    pub fn set_regular_oversampling(&mut self, reg_oversampl : RegularOversampling){
+        self.adc.cfgr2.modify(|_, w| w.rovse().bit(reg_oversampl == RegularOversampling::On))
+    }
+
+    pub fn set_injected_oversampling(&mut self, inj_oversampl : InjectedOversampling){
+        self.adc.cfgr2.modify(|_, w| w.jovse().bit(inj_oversampl == InjectedOversampling::On))
+    }
+
+    pub fn set_oversampling_ratio(&mut self, oversampl_ratio : OversamplingRatio){
+        self.adc.cfgr2.modify(|_, w| unsafe{ w.ovsr().bits(oversampl_ratio as u8)})
+    }
+
+    pub fn set_oversampling_shift(&mut self, oversampl_shift : OversamplingShift){
+        self.adc.cfgr2.modify(|_, w| unsafe{ w.ovss().bits(oversampl_shift as u8)})
+    }
+
 }
 
+
+
 #[cfg(feature = "stm32l4x6")]
-impl<WORD, PIN> OneShot<Adc<crate::device::ADC1>, WORD, PIN> for Adc<crate::stm32::ADC1>
+impl<WORD, PIN> OneShot<Adc<ADC1>, WORD, PIN> for Adc<ADC1>
 where
     WORD: From<u16>,
-    PIN: Channel<Adc<crate::device::ADC1>, ID = u8>,
+    PIN: AdcChannel<ADC1> + Channel<Adc<ADC1>, ID = u8>,
 {
     type Error = ();
 
-    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        
         self.power_up();
-        self.adc.cfgr.modify(|_, w| unsafe { w.exten().bits(0b00) });
+
+        //Save ADC state
+        //Note: Sampling time for pin is not restored
+        let cont_mode = self.adc.cfgr.read().cont().bit_is_set();
+        let external_trig = self.adc.cfgr.read().exten().bits();
+        let seq_1 = self.adc.sqr1.read().sq1().bits();
+        let seq_len = self.adc.sqr1.read().l().bits();
+
+        pin.setup(&mut self.adc, self.config.sample_time);
+
         self.adc
             .cfgr
-            .modify(|_, w| unsafe { w.align().clear_bit().res().bits(0b00).cont().clear_bit() });
+            .modify(|_, w| w.cont().clear_bit());
+        self.adc
+            .cfgr
+            .modify(|_, w| unsafe { w.exten().bits(0b00) });
         self.adc
             .sqr1
             .modify(|_, w| unsafe { w.sq1().bits(PIN::channel()) });
         self.adc
-            .cfgr2
-            .modify(|_, w| unsafe { w.rovse().set_bit().ovsr().bits(0b011) });
+            .sqr1
+            .modify(|_, w| unsafe { w.l().bits(0b0000)});
+
         self.adc.isr.modify(|_, w| w.eoc().set_bit());
         self.adc.cr.modify(|_, w| w.adstart().set_bit());
 
-        //        cortex_m::asm::delay(80_000_000);
         while self.adc.isr.read().eoc().bit_is_clear() {}
 
         let val = self.adc.dr.read().rdata().bits().into();
+
+        //Restore state
+        self.adc
+            .cfgr
+            .modify(|_, w| w.cont().bit(cont_mode));
+        self.adc
+            .cfgr
+            .modify(|_, w| unsafe { w.exten().bits(external_trig) });
+        self.adc
+            .sqr1
+            .modify(|_, w| unsafe { w.sq1().bits(seq_1) });
+        self.adc
+            .sqr1
+            .modify(|_, w| unsafe { w.l().bits(seq_len)});
+
         self.power_down();
         Ok(val)
+    }
+}
+
+
+
+macro_rules! int_adc {
+    ($($Chan:ident: ($chan:expr, $en:ident)),+ $(,)*) => {
+        $(
+            pub struct $Chan;
+
+            impl $Chan {
+                pub fn new() -> Self {
+                    Self {}
+                }
+
+
+                pub fn enable(&mut self) {
+                    let adc_common = unsafe { &*crate::device::ADC_COMMON::ptr() };
+                    adc_common.ccr.modify(|_, w| w.$en().set_bit());
+                }
+
+                pub fn disable(&mut self) {
+                    let adc_common = unsafe { &*crate::device::ADC_COMMON::ptr() };
+                    adc_common.ccr.modify(|_, w| w.$en().clear_bit());
+                }
+
+                pub fn is_enabled(&mut self) -> bool {
+                    let adc_common = unsafe { &*crate::device::ADC_COMMON::ptr() };
+                    adc_common.ccr.read().$en().bit_is_set()
+                }
+            }
+        )+
+    };
+}
+int_adc! {
+    VTemp: (17, ch17sel),
+    VRef: (0, vrefen),
+    VBat: (18, ch18sel)
+}
+
+
+pub trait AdcChannel<T> {
+    fn setup(&mut self, adc: &mut T, sample_time : SampleTime);
+}
+
+macro_rules! adc_pins {
+    ($($Adc:ty: ($Chan:ty: ($pin:ty, $chan:expr, $smprx:ident))),+ $(,)*) => {
+        $(
+            impl Channel<Adc<$Adc>> for $pin {
+                type ID = u8;
+
+                fn channel() -> u8 { $chan }
+            }
+
+            impl AdcChannel <$Adc> for $pin {
+                fn setup(&mut self, adc: &mut $Adc, sample_time : SampleTime) {
+                    adc.$smprx.modify(|r, w| unsafe {
+                        const OFFSET: u8 = 3 * $chan % 10;
+                        let mut bits = r.bits() as u32;
+                        bits &= !(0xfff << OFFSET);
+                        bits |= (sample_time as u32) << OFFSET;
+                        w.bits(bits)
+                    });
+                    // adc.rb.sqr5.write(|w| unsafe { w.sq1().bits($chan) });
+                }
+            }
+        )+
+    };
+}
+
+adc_pins! {
+    ADC1: (Channel5: (gpioa::PA0<Analog>, 5_u8, smpr1)),
+    ADC1: (Channel6: (gpioa::PA1<Analog>, 6_u8, smpr1)),
+    
+    ADC1: (VTemp: (VTemp, 17_u8, smpr2)),
+    ADC1: (VBat: (VBat, 18_u8, smpr2)),
+}
+
+//Special case Setup for VRef
+impl Channel<Adc<ADC1>> for VRef {
+    type ID = u8;
+
+    fn channel() -> u8 { 0 }
+}
+impl AdcChannel <ADC1> for VRef {
+    fn setup(&mut self, _adc: &mut ADC1, _sample_time : SampleTime) {
+        
+    }
+}
+
+
+impl VTemp{
+    fn convert_temp(vtemp: u16, vdda: u16) -> i16 {
+        let vtemp30_cal = i32::from(unsafe { ptr::read(VTEMPCAL30) }) * 100;
+        let vtemp110_cal = i32::from(unsafe { ptr::read(VTEMPCAL110) }) * 100;
+
+        let mut temperature = i32::from(vtemp) * 100;
+        temperature = (temperature * (i32::from(vdda) / i32::from(VDD_CALIB))) - vtemp30_cal;
+        temperature *= (110 - 30) * 100;
+        temperature /= vtemp110_cal - vtemp30_cal;
+        temperature += 3000;
+        temperature as i16
+
+    }
+
+    pub fn get_cal() -> (i32, i32){
+        let vtemp30_cal = i32::from(unsafe { ptr::read(VTEMPCAL30) }) * 100;
+        let vtemp110_cal = i32::from(unsafe { ptr::read(VTEMPCAL110) }) * 100;
+        (vtemp30_cal, vtemp110_cal)
+    }
+
+    /// Read the value of the internal temperature sensor and return the
+    /// result in 100ths of a degree centigrade.
+    ///
+    /// Given a delay reference it will attempt to restrict to the
+    /// minimum delay needed to ensure a 10 us t<sub>START</sub> value.
+    /// Otherwise it will approximate the required delay using ADC reads.
+    //Presumes ADC is setup for reciving a single measurement
+    pub fn read(adc: &mut Adc<ADC1>) -> i16 {
+        let mut vtemp = Self::new();
+        let vtemp_preenable = vtemp.is_enabled();
+
+        if !vtemp_preenable {
+            vtemp.enable();
+            //Delay set for worst case senario for STM32L475
+            cortex_m::asm::delay(40);
+
+        }
+
+        let vdda = VRef::read_vdda(adc);
+
+        let prev_cfg = adc.get_config();
+        
+        //Sample time dependant on electrical caracteristics for temp sensor here STM32L475
+        adc.apply_config(Config::default().sample_time(SampleTime::T47_5));
+
+        let vtemp_val = adc.read(&mut vtemp).unwrap();
+
+        if !vtemp_preenable {
+            vtemp.disable();
+        }
+
+        adc.apply_config(prev_cfg);
+
+        Self::convert_temp(vtemp_val, vdda)
+    }
+}
+
+
+impl VRef {
+    /// Reads the value of VDDA in milli-volts
+    pub fn read_vdda(adc: &mut Adc<ADC1>) -> u16 {
+        let vrefint_cal = u32::from(unsafe { ptr::read(VREFCAL) });
+        let mut vref = Self::new();
+
+        let prev_cfg = adc.default_config();
+        // let prev_cfg = adc.get_config();
+        // adc.apply_config(Config::default().sample_time(SampleTime::T640_5));
+
+        let vref_preenable = vref.is_enabled();
+
+        if !vref_preenable {
+            vref.enable();
+        }
+
+        let vref_val: u32 = adc.read(&mut vref).unwrap();
+       
+        if !vref_preenable{
+            vref.disable();
+        }
+
+        adc.apply_config(prev_cfg);
+
+        (u32::from(VDD_CALIB) * vrefint_cal / vref_val) as u16
     }
 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -4,11 +4,6 @@ use crate::rcc::AHB2;
 //use core::marker::PhantomData;
 use embedded_hal::adc::{Channel, OneShot};
 
-#[cfg(feature = "stm32l4x6")]
-use stm32l4::stm32l4x6::{
-    rcc::CCIPR,
-    ADC1
-};
 
 #[cfg(feature = "stm32l4x6")]
 pub struct Adc<ADC1> {
@@ -79,7 +74,7 @@ where
 {
     type Error = ();
 
-    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
         self.power_up();
         self.adc.cfgr.modify(|_, w| unsafe { w.exten().bits(0b00) });
         self.adc

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -4,8 +4,13 @@ use crate::rcc::AHB2;
 use core::marker::PhantomData;
 use embedded_hal::adc::{Channel, OneShot};
 
-#[cfg(feature = "stm32l4x2",feature = "stm32l4x6")]
+#[cfg(feature = "stm32l4x2")]
 use stm32l4::stm32l4x2::{
+    rcc::CCIPR,
+    ADC
+};
+#[cfg(feature = "stm32l4x6")]
+use stm32l4::stm32l4x6::{
     rcc::CCIPR,
     ADC
 };

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -24,7 +24,7 @@ impl Adc<crate::device::ADC1> {
         // Disable deep power down and start ADC voltage regulator
         adc.cr.modify(|_, w| w.deeppwd().clear_bit());
         adc.cr.modify(|_, w| w.advregen().set_bit());
-        cortex_m::asm::delay(8_000_000);
+        // cortex_m::asm::delay(8_000_000);
 
         // Calibrate
         adc.cr.modify(|_, w| w.adcaldif().clear_bit());

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -119,7 +119,7 @@ impl Config {
             Some(BitReversal::ByWord) => 0b11,
         };
 
-        crc.init.write(|w| { w.init().bits(init) });
+        crc.init.write(|w| w.init().bits(init));
         crc.pol.write(|w| unsafe { w.bits(poly) });
         crc.cr.write(|w| {
             {
@@ -162,8 +162,7 @@ impl Crc {
     pub fn reset_with_inital_value(&mut self, initial_value: u32) {
         let crc = unsafe { &(*CRC::ptr()) };
 
-        crc.init
-            .write(|w| { w.init().bits(initial_value) });
+        crc.init.write(|w| w.init().bits(initial_value));
         crc.cr.modify(|_, w| w.reset().set_bit());
     }
 

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -119,7 +119,7 @@ impl Config {
             Some(BitReversal::ByWord) => 0b11,
         };
 
-        crc.init.write(|w| unsafe { w.crc_init().bits(init) });
+        crc.init.write(|w| unsafe { w.init().bits(init) });
         crc.pol.write(|w| unsafe { w.bits(poly) });
         crc.cr.write(|w| {
             unsafe {
@@ -163,7 +163,7 @@ impl Crc {
         let crc = unsafe { &(*CRC::ptr()) };
 
         crc.init
-            .write(|w| unsafe { w.crc_init().bits(initial_value) });
+            .write(|w| unsafe { w.init().bits(initial_value) });
         crc.cr.modify(|_, w| w.reset().set_bit());
     }
 
@@ -175,7 +175,7 @@ impl Crc {
             unsafe {
                 // Workaround with svd2rust, it does not generate the byte interface to the DR
                 // register
-                ptr::write_volatile(&crc.dr as *const _ as *mut u8, *byte);
+                ptr::write_volatile(&crc.dr() as *const _ as *mut u8, *byte);
             }
         }
     }
@@ -197,7 +197,7 @@ impl Crc {
     pub fn peek_result(&self) -> u32 {
         let crc = unsafe { &(*CRC::ptr()) };
 
-        crc.dr.read().bits()
+        crc.dr().read().bits()
     }
 }
 

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -119,10 +119,10 @@ impl Config {
             Some(BitReversal::ByWord) => 0b11,
         };
 
-        crc.init.write(|w| unsafe { w.init().bits(init) });
+        crc.init.write(|w| { w.init().bits(init) });
         crc.pol.write(|w| unsafe { w.bits(poly) });
         crc.cr.write(|w| {
-            unsafe {
+            {
                 w.rev_in()
                     .bits(in_rev_bits)
                     .polysize()
@@ -163,7 +163,7 @@ impl Crc {
         let crc = unsafe { &(*CRC::ptr()) };
 
         crc.init
-            .write(|w| unsafe { w.init().bits(initial_value) });
+            .write(|w| { w.init().bits(initial_value) });
         crc.cr.modify(|_, w| w.reset().set_bit());
     }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -399,7 +399,7 @@ macro_rules! dma {
                         /// `inc` indicates whether the address will be incremented after every byte transfer
                         #[inline]
                         pub fn set_peripheral_address(&mut self, address: u32, inc: bool) {
-                            self.cpar().write(|w| w.pa().bits(address) );
+                            unsafe {self.cpar().write(|w| w.pa().bits(address) ) };
                             self.ccr().modify(|_, w| w.pinc().bit(inc) );
                         }
 
@@ -408,7 +408,7 @@ macro_rules! dma {
                         /// `inc` indicates whether the address will be incremented after every byte transfer
                         #[inline]
                         pub fn set_memory_address(&mut self, address: u32, inc: bool) {
-                            self.cmar().write(|w| w.ma().bits(address) );
+                            unsafe {self.cmar().write(|w| w.ma().bits(address) ) };
                             self.ccr().modify(|_, w| w.minc().bit(inc) );
                         }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -466,12 +466,8 @@ macro_rules! gpio {
                     ) -> $PXi<Analog> {
                         let offset = 2 * $i;
                         
-                        // stitch control register
-                        unsafe {
-                            &(*$GPIOX::ptr()).ascr.modify(|r, w| {
-                                w.bits(r.bits() | 0b1 << $i)
-                            })
-                        };
+                        // switch control register
+                        
 
                         // analog mode
                         let mode = 0b11;
@@ -483,6 +479,11 @@ macro_rules! gpio {
                             .pupdr()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
                         
+                        unsafe {
+                            &(*$GPIOX::ptr()).ascr.modify(|r, w| {
+                                w.bits(r.bits() | 0b1 << $i)
+                            })
+                        };
                         // not supported 
                         // ascr.ascr().modify(|r, w| unsafe { w.bits(r.bits() | 0b1 << $i) });
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -22,6 +22,7 @@ pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
 ///  Analog
+#[cfg(feature="stm32l4x6")]
 pub struct Analog;
 /// Floating input (type state)
 pub struct Floating;
@@ -182,13 +183,13 @@ macro_rules! gpio {
 
             use crate::rcc::{AHB2, APB2};
             use super::{
-
                 Alternate, AlternateOD,
                 AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15,
-                Floating, GpioExt, Input, OpenDrain, Output, Edge, ExtiPin, Analog,
+                Floating, GpioExt, Input, OpenDrain, Output, Edge, ExtiPin,
                 PullDown, PullUp, PushPull, State, Speed,
             };
-
+            #[cfg(feature="stm32l4x6")]
+            use super::Analog;
             /// GPIO parts
             pub struct Parts {
                 /// Opaque AFRH register
@@ -457,7 +458,7 @@ macro_rules! gpio {
 
                         $PXi { _mode: PhantomData }
                     }
-                    
+                    #[cfg(feature="st32l4x6")]
                     /// Configures the pin to operate as an analog pin with adc.
                     pub fn into_analog_with_adc(
                         self,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -459,13 +459,19 @@ macro_rules! gpio {
                     }
                     
                     /// Configures the pin to operate as an analog pin
-                    pub fn into_analog(
+                    pub fn into_analog_with_adc(
                         self,
                         moder: &mut MODER,
-                        pupdr: &mut PUPDR,
-//                        ascr: &mut ASCR,
+                        pupdr: &mut PUPDR
                     ) -> $PXi<Analog> {
                         let offset = 2 * $i;
+                        
+                        // stitch control register
+                        unsafe {
+                            &(*$GPIOX::ptr()).ascr.modify(|r, w| {
+                                w.bits(r.bits() | 0b1 << $i)
+                            })
+                        };
 
                         // analog mode
                         let mode = 0b11;
@@ -476,8 +482,9 @@ macro_rules! gpio {
                         pupdr
                             .pupdr()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
-
-//                        ascr.ascr().modify(|r, w| unsafe { w.bits(r.bits() | 0b1 << $i) });
+                        
+                        // not supported 
+                        // ascr.ascr().modify(|r, w| unsafe { w.bits(r.bits() | 0b1 << $i) });
 
                         $PXi { _mode: PhantomData }
                     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -22,7 +22,7 @@ pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
 ///  Analog
-#[cfg(feature="stm32l4x6")]
+#[cfg(feature = "stm32l4x6")]
 pub struct Analog;
 /// Floating input (type state)
 pub struct Floating;
@@ -188,8 +188,6 @@ macro_rules! gpio {
                 Floating, GpioExt, Input, OpenDrain, Output, Edge, ExtiPin,
                 PullDown, PullUp, PushPull, State, Speed,
             };
-            #[cfg(feature="stm32l4x6")]
-            use super::Analog;
             /// GPIO parts
             pub struct Parts {
                 /// Opaque AFRH register
@@ -458,14 +456,14 @@ macro_rules! gpio {
 
                         $PXi { _mode: PhantomData }
                     }
-                    #[cfg(feature="st32l4x6")]
+                    #[cfg(feature = "st32l4x6")]
                     /// Configures the pin to operate as an analog pin with adc.
                     pub fn into_analog_with_adc(
                         self,
                         moder: &mut MODER,
                         pupdr: &mut PUPDR
                     ) -> $PXi<Analog> {
-                        let offset = 2 * $i;                        
+                        let offset = 2 * $i;
 
                         // analog mode
                         let mode = 0b11;
@@ -476,7 +474,7 @@ macro_rules! gpio {
                         pupdr
                             .pupdr()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
-                        
+
                         // Required for STM32L47x/L48x devices(RM351).
                         // using more unsafe version since ascr field is not supported yet.
                         unsafe {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -458,16 +458,13 @@ macro_rules! gpio {
                         $PXi { _mode: PhantomData }
                     }
                     
-                    /// Configures the pin to operate as an analog pin
+                    /// Configures the pin to operate as an analog pin with adc.
                     pub fn into_analog_with_adc(
                         self,
                         moder: &mut MODER,
                         pupdr: &mut PUPDR
                     ) -> $PXi<Analog> {
-                        let offset = 2 * $i;
-                        
-                        // switch control register
-                        
+                        let offset = 2 * $i;                        
 
                         // analog mode
                         let mode = 0b11;
@@ -479,12 +476,14 @@ macro_rules! gpio {
                             .pupdr()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
                         
+                        // Required for STM32L47x/L48x devices(RM351).
+                        // using more unsafe version since ascr field is not supported yet.
                         unsafe {
                             &(*$GPIOX::ptr()).ascr.modify(|r, w| {
                                 w.bits(r.bits() | 0b1 << $i)
-                            })
+                            });
                         };
-                        // not supported 
+                        // not supported (same as above)
                         // ascr.ascr().modify(|r, w| unsafe { w.bits(r.bits() | 0b1 << $i) });
 
                         $PXi { _mode: PhantomData }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -21,7 +21,8 @@ pub trait GpioExt {
 pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
-
+///  Analog
+pub struct Analog;
 /// Floating input (type state)
 pub struct Floating;
 /// Pulled down input (type state)
@@ -184,7 +185,7 @@ macro_rules! gpio {
 
                 Alternate, AlternateOD,
                 AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15,
-                Floating, GpioExt, Input, OpenDrain, Output, Edge, ExtiPin,
+                Floating, GpioExt, Input, OpenDrain, Output, Edge, ExtiPin, Analog,
                 PullDown, PullUp, PushPull, State, Speed,
             };
 
@@ -453,6 +454,30 @@ macro_rules! gpio {
                         pupdr.pupdr().modify(|r, w| unsafe {
                             w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                         });
+
+                        $PXi { _mode: PhantomData }
+                    }
+                    
+                    /// Configures the pin to operate as an analog pin
+                    pub fn into_analog(
+                        self,
+                        moder: &mut MODER,
+                        pupdr: &mut PUPDR,
+//                        ascr: &mut ASCR,
+                    ) -> $PXi<Analog> {
+                        let offset = 2 * $i;
+
+                        // analog mode
+                        let mode = 0b11;
+                        moder.moder().modify(|r, w| unsafe {
+                            w.bits((r.bits() & !(0b11 << offset)) | (mode << offset))
+                        });
+
+                        pupdr
+                            .pupdr()
+                            .modify(|r, w| unsafe { w.bits(r.bits() & !(0b11 << offset)) });
+
+//                        ascr.ascr().modify(|r, w| unsafe { w.bits(r.bits() | 0b1 << $i) });
 
                         $PXi { _mode: PhantomData }
                     }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -327,32 +327,15 @@ hal! {
 use crate::gpio::gpioa::{PA10, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 
-pins!(I2C1, AF4,
-    SCL: [PA9, PB6],
-    SDA: [PA10, PB7]);
+pins!(I2C1, AF4, SCL: [PA9, PB6], SDA: [PA10, PB7]);
 
-pins!(I2C2, AF4,
-    SCL: [PB10],
-    SDA: [PB11]);
+pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x6"
-))]
+#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
 use crate::gpio::gpiob::{PB13, PB14, PB8, PB9};
 
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x6"
-))]
-pins!(I2C1, AF4,
-    SCL: [PB8],
-    SDA: [PB9]);
+#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
+pins!(I2C1, AF4, SCL: [PB8], SDA: [PB9]);
 
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x6"
-))]
-pins!(I2C2, AF4,
-    SCL: [PB13],
-    SDA: [PB14]);
+#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
+pins!(I2C2, AF4, SCL: [PB13], SDA: [PB14]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ compile_error!("This crate requires one of the following features enabled: stm32
 
 pub use embedded_hal as hal;
 
+pub mod adc;
+
 pub use stm32l4;
 #[cfg(feature = "stm32l4x1")]
 pub use stm32l4::stm32l4x1 as pac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ compile_error!("This crate requires one of the following features enabled: stm32
 
 pub use embedded_hal as hal;
 
-pub mod adc;
 
 pub use stm32l4;
 #[cfg(feature = "stm32l4x1")]
@@ -42,6 +41,9 @@ pub use stm32l4::stm32l4x6 as pac;
 
 #[cfg(feature = "rt")]
 pub use self::pac::interrupt;
+
+#[cfg(feature = "stm32lx6")]
+pub mod adc;
 
 #[cfg(any(
     feature = "stm32l4x1",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ compile_error!("This crate requires one of the following features enabled: stm32
 
 pub use embedded_hal as hal;
 
-
 pub use stm32l4;
 #[cfg(feature = "stm32l4x1")]
 pub use stm32l4::stm32l4x1 as pac;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -7,7 +7,7 @@ use crate::hal;
 use crate::stm32::{TIM1, TIM15, TIM2};
 
 use crate::gpio::gpioa::{PA0, PA1, PA10, PA11, PA2, PA3, PA8, PA9};
-use crate::gpio::gpiob::{PB14};
+use crate::gpio::gpiob::PB14;
 use crate::gpio::{Alternate, AlternateOD, Floating, Input, Output, PushPull, AF1};
 use crate::rcc::{Clocks, APB1R1, APB2};
 use crate::time::Hertz;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -113,7 +113,7 @@ pub struct Rcc {
     /// Clock recovery RC register
     pub crrcr: CRRCR,
     /// Peripherals independent clock configuration register
-    pub ccipr : CCIPR,
+    pub ccipr: CCIPR,
 }
 
 /// Peripherals independent clock configuration register

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -85,6 +85,7 @@ impl RccExt for RCC {
                 pll_source: None,
                 pll_config: None,
             },
+            ccipr: CCIPR { _0: () },
         }
     }
 }
@@ -111,6 +112,22 @@ pub struct Rcc {
     pub csr: CSR,
     /// Clock recovery RC register
     pub crrcr: CRRCR,
+    /// Peripherals independent clock configuration register
+    pub ccipr : CCIPR,
+}
+
+/// Peripherals independent clock configuration register
+pub struct CCIPR {
+    _0: (),
+}
+
+impl CCIPR {
+    // TODO remove `allow`
+    #[allow(dead_code)]
+    pub(crate) fn ccipr(&mut self) -> &rcc::CCIPR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).ccipr }
+    }
 }
 
 /// CSR Control/Status Register


### PR DESCRIPTION
Adc1 partial support. Implements OneShot trait which enables reading an analog value in every call. Tested with stm32l476 and stm32l496 a potentiometer.