### PR TITLE
Added less used USART3 config for l4x5 and l4x6

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -77,7 +77,7 @@ use crate::gpio::gpiob::PB5;
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 use crate::gpio::gpioc::PC12;
 
-#[cfg(any(feature = "stm32l4x5"))]
+#[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 use crate::gpio::gpiod::{PD8, PD9};
 
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
@@ -441,14 +441,10 @@ pins! {
     USART3: (PC10, PC11, PD12, AF7),
 }
 
-#[cfg(any(
-    feature = "stm32l4x5",
-    feature = "stm32l4x6",
-))]
+#[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6"))]
 pins! {
     USART3: (PD8, PD9, PB1, PA6, AF7),
 }
-
 
 // UART 4
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -441,7 +441,7 @@ pins! {
     USART3: (PC10, PC11, PD12, AF7),
 }
 
-#[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6"))]
+#[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 pins! {
     USART3: (PD8, PD9, PB1, PA6, AF7),
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -77,6 +77,9 @@ use crate::gpio::gpiob::PB5;
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 use crate::gpio::gpioc::PC12;
 
+#[cfg(any(feature = "stm32l4x5"))]
+use crate::gpio::gpiod::{PD8, PD9};
+
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 use crate::gpio::AF8;
 
@@ -437,6 +440,15 @@ pins! {
     USART3: (PC10, PC11, PD2, AF7),
     USART3: (PC10, PC11, PD12, AF7),
 }
+
+#[cfg(any(
+    feature = "stm32l4x5",
+    feature = "stm32l4x6",
+))]
+pins! {
+    USART3: (PD8, PD9, PB1, PA6, AF7),
+}
+
 
 // UART 4
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]


### PR DESCRIPTION
Adding a less used USART3 config for  `stm32l4x5` and `stm32l4x6`.