### PR TITLE
Add VS Code config to make rust-analyzer work

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "stm32l4x3",
         "rt"
     ],
-    "rust-analyzer.checkOnSave.allTargets": false
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.cargo.features": [
+        "stm32l4x3",
+        "rt"
+    ],
+    "rust-analyzer.checkOnSave.allTargets": false
+}


### PR DESCRIPTION
I realize that not everyone is using VS Code, but this configuration
will be helpful to anyone using it with this repository, while having
little to no impact on anyone else.

Please note that this configuration selects the Cargo feature that
matches my hardware. It might not be appropriate to others. I can't
really think of a better solution, except maybe not to add this
configuration at all.