### PR TITLE
Add cargo-embed configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@
 **/*.rs.bk
 Cargo.lock
 
+# cargo-embed
+/Embed.local.toml
+/logs
+
 # Visual Studio Code
 /.vscode

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,12 @@
+[default.general]
+# This is just an example that might not fit your target hardware. Create a file
+# called "Embed.local.toml" in the same directory, and override this setting
+# there. You can get a list of valid options by running
+# `cargo embed --list-chips`.
+chip = "STM32L433RCTx"
+
+[default.rtt]
+# Disabled by default, as RTT is not enabled for all examples in this
+# repository. Enable it in "Embed.local.toml", if you need it.
+enabled = false
+log_enabled = true


### PR DESCRIPTION
cargo-embed is much more pleasant to use than OpenOCD, and I think it's a good idea to support it. This PR adds default configuration (including documentation on how to override it) and updates .gitignore as necessary.