### PR TITLE
Upgrade to latest version of `stm32l4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6.3"
 nb = "0.1.1"
-stm32l4 = "0.11.0"
+stm32l4 = "0.12.1"
 as-slice = "0.1"
 generic-array = "0.13"
 

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -19,7 +19,6 @@
 use crate::rcc;
 use crate::stm32::CRC;
 use core::hash::Hasher;
-use core::ptr;
 
 /// Extension trait to constrain the CRC peripheral.
 pub trait CrcExt {
@@ -119,17 +118,15 @@ impl Config {
             Some(BitReversal::ByWord) => 0b11,
         };
 
-        crc.init.write(|w| unsafe { w.crc_init().bits(init) });
+        crc.init.write(|w| w.init().bits(init));
         crc.pol.write(|w| unsafe { w.bits(poly) });
         crc.cr.write(|w| {
-            unsafe {
-                w.rev_in()
-                    .bits(in_rev_bits)
-                    .polysize()
-                    .bits(poly_bits)
-                    .reset()
-                    .set_bit();
-            }
+            w.rev_in()
+                .bits(in_rev_bits)
+                .polysize()
+                .bits(poly_bits)
+                .reset()
+                .set_bit();
 
             if self.output_bit_reversal {
                 w.rev_out().set_bit()
@@ -162,8 +159,7 @@ impl Crc {
     pub fn reset_with_inital_value(&mut self, initial_value: u32) {
         let crc = unsafe { &(*CRC::ptr()) };
 
-        crc.init
-            .write(|w| unsafe { w.crc_init().bits(initial_value) });
+        crc.init.write(|w| w.init().bits(initial_value));
         crc.cr.modify(|_, w| w.reset().set_bit());
     }
 
@@ -171,12 +167,8 @@ impl Crc {
     #[inline]
     pub fn feed(&mut self, data: &[u8]) {
         let crc = unsafe { &(*CRC::ptr()) };
-        for byte in data {
-            unsafe {
-                // Workaround with svd2rust, it does not generate the byte interface to the DR
-                // register
-                ptr::write_volatile(&crc.dr as *const _ as *mut u8, *byte);
-            }
+        for &byte in data {
+            crc.dr8().write(|w| w.dr8().bits(byte));
         }
     }
 
@@ -197,7 +189,7 @@ impl Crc {
     pub fn peek_result(&self) -> u32 {
         let crc = unsafe { &(*CRC::ptr()) };
 
-        crc.dr.read().bits()
+        crc.dr().read().bits()
     }
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -417,7 +417,9 @@ macro_rules! dma {
                         /// `inc` indicates whether the address will be incremented after every byte transfer
                         #[inline]
                         pub fn set_peripheral_address(&mut self, address: u32, inc: bool) {
-                            self.cpar().write(|w| w.pa().bits(address) );
+                            self.cpar().write(|w|
+                                unsafe { w.pa().bits(address) }
+                            );
                             self.ccr().modify(|_, w| w.pinc().bit(inc) );
                         }
 
@@ -426,7 +428,9 @@ macro_rules! dma {
                         /// `inc` indicates whether the address will be incremented after every byte transfer
                         #[inline]
                         pub fn set_memory_address(&mut self, address: u32, inc: bool) {
-                            self.cmar().write(|w| w.ma().bits(address) );
+                            self.cmar().write(|w|
+                                unsafe { w.ma().bits(address) }
+                            );
                             self.ccr().modify(|_, w| w.minc().bit(inc) );
                         }
 


### PR DESCRIPTION
This required changes to the `crc` and `dma` modules. I've tested
examples/rtic_frame_serial_dma.rs (which works for me), but there
doesn't seem to be a CRC example I can test.