### PR TITLE
Started a free running timer based on normal timers

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -115,8 +115,10 @@ macro_rules! hal {
                     apb.rstr().modify(|_, w| w.$timXrst().clear_bit());
 
                     let frequency = frequency.into();
-                    let psc = clocks.pclk1().0 / frequency.0;
+                    let psc = clocks.pclk1().0 / frequency.0 - 1;
 
+                    debug_assert!(clocks.pclk1().0 >= frequency.0);
+                    debug_assert!(frequency.0 > 0);
                     debug_assert!(psc <= core::u16::MAX.into());
 
                     tim.psc.write(|w| w.psc().bits((psc as u16).into()) );

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -222,6 +222,6 @@ hal! {
 #[cfg(any(feature = "stm32l4x5", feature = "stm32l4x6",))]
 hal! {
     TIM4:  (tim4, free_running_tim4, tim4en, tim4rst, APB1R1, u16),
-    TIM5:  (tim5, free_running_tim5, tim5en, tim5rst, APB1R1, u16),
+    TIM5:  (tim5, free_running_tim5, tim5en, tim5rst, APB1R1, u32),
     TIM17: (tim17, free_running_tim17, tim17en, tim17rst, APB2, u16),
 }


### PR DESCRIPTION
I started some work on a monotonic implementation for general timers in the HAL.

This should probably be merged with the DWT implementation that exists now as well under the `MonoTimer` struct.
I am not currently sure on how to design this so I made this in the meantime.

Any ideas on how we should merge the interfaces? 