### PR TITLE
Ignore local cargo-embed config and RTT logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@
 **/*.rs.bk
 Cargo.lock
 
+# cargo-embed
+/Embed.local.toml
+/logs
+
 # Visual Studio Code
 /.vscode


### PR DESCRIPTION
Adds local cargo-embed configuration and the directory it uses for log files to .gitignore. This improves the convenience for everyone who prefers to use cargo-embed to run examples in this repository.

This is a maybe less controversial alternative to #154.