### PR TITLE
Opt into blocking write impl for `serial::Tx`

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -496,6 +496,9 @@ macro_rules! hal {
                 }
             }
 
+            impl embedded_hal::blocking::serial::write::Default<u8>
+                for Tx<pac::$USARTX> {}
+
             impl Rx<pac::$USARTX> {
                 pub fn circ_read<B, H>(
                     &self,


### PR DESCRIPTION
This opts into the default implementation of `serial::blocking::Write`,
providing the `bwrite_all` and `bflush` methods.