### PR TITLE
adding i2c pins for stm32l4x3

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -556,7 +556,7 @@ pins!(I2C1, AF4,
 ))]
 pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
-#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x3"))]
+#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x3", feature = "stm32l4x6"))]
 use crate::gpio::gpiob::PB8;
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -3,7 +3,7 @@
 use crate::gpio::{Alternate, OpenDrain, Output, AF4};
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 use crate::rcc::{Clocks, APB1R1};
-#[cfg(feature = "stm32l4x5")]
+#[cfg(any(feature = "stm32l4x3", feature = "stm32l4x5"))]
 use crate::stm32::I2C3;
 use crate::stm32::{i2c1, I2C1, I2C2};
 use crate::time::Hertz;
@@ -517,20 +517,54 @@ where
     }
 }
 
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x4",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6",
+))]
 use crate::gpio::gpioa::{PA10, PA9};
-use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 
-#[cfg(feature = "stm32l4x5")]
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x4",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6",
+))]
+use crate::gpio::gpiob::{PB10, PB11, PB6};
+
+use crate::gpio::gpiob::PB7;
+
+#[cfg(any(feature = "stm32l4x3", feature = "stm32l4x5"))]
 use crate::gpio::gpioc::{PC0, PC1};
 
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x4",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6",
+))]
 pins!(I2C1, AF4,
     SCL: [PA9, PB6],
     SDA: [PA10, PB7]);
 
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x4",
+    feature = "stm32l4x5",
+    feature = "stm32l4x6",
+))]
 pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
+#[cfg(feature = "stm32l4x3")]
+use crate::gpio::gpiob::PB8;
+
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
-use crate::gpio::gpiob::{PB13, PB14, PB8, PB9};
+use crate::gpio::gpiob::{PB13, PB14, PB9};
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
 pins!(I2C1, AF4, SCL: [PB8], SDA: [PB9]);
@@ -539,4 +573,10 @@ pins!(I2C1, AF4, SCL: [PB8], SDA: [PB9]);
 pins!(I2C2, AF4, SCL: [PB13], SDA: [PB14]);
 
 #[cfg(feature = "stm32l4x5")]
+pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);
+
+#[cfg(feature = "stm32l4x3")]
+pins!(I2C1, AF4, SCL: [PB8], SDA: [PB7]);
+
+#[cfg(feature = "stm32l4x3")]
 pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -560,7 +560,7 @@ pins!(I2C1, AF4,
 ))]
 pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
-#[cfg(feature = "stm32l4x3")]
+#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x3"))]
 use crate::gpio::gpiob::PB8;
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -3,7 +3,7 @@
 use crate::gpio::{Alternate, OpenDrain, Output, AF4};
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 use crate::rcc::{Clocks, APB1R1};
-#[cfg(any(feature = "stm32l4x3", feature = "stm32l4x5"))]
+#[cfg(feature = "stm32l4x5")]
 use crate::stm32::I2C3;
 use crate::stm32::{i2c1, I2C1, I2C2};
 use crate::time::Hertz;
@@ -575,4 +575,4 @@ pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);
 pins!(I2C1, AF4, SCL: [PB8], SDA: [PB7]);
 
 #[cfg(feature = "stm32l4x3")]
-pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);
+pins!(I2C2, AF4, SCL: [PC0], SDA: [PC1]);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -520,7 +520,6 @@ where
 #[cfg(any(
     feature = "stm32l4x1",
     feature = "stm32l4x2",
-    feature = "stm32l4x4",
     feature = "stm32l4x5",
     feature = "stm32l4x6",
 ))]
@@ -529,7 +528,6 @@ use crate::gpio::gpioa::{PA10, PA9};
 #[cfg(any(
     feature = "stm32l4x1",
     feature = "stm32l4x2",
-    feature = "stm32l4x4",
     feature = "stm32l4x5",
     feature = "stm32l4x6",
 ))]
@@ -543,7 +541,6 @@ use crate::gpio::gpioc::{PC0, PC1};
 #[cfg(any(
     feature = "stm32l4x1",
     feature = "stm32l4x2",
-    feature = "stm32l4x4",
     feature = "stm32l4x5",
     feature = "stm32l4x6",
 ))]
@@ -554,7 +551,6 @@ pins!(I2C1, AF4,
 #[cfg(any(
     feature = "stm32l4x1",
     feature = "stm32l4x2",
-    feature = "stm32l4x4",
     feature = "stm32l4x5",
     feature = "stm32l4x6",
 ))]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -517,50 +517,23 @@ where
     }
 }
 
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x2",
-    feature = "stm32l4x5",
-    feature = "stm32l4x6",
-))]
 use crate::gpio::gpioa::{PA10, PA9};
-
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x2",
-    feature = "stm32l4x5",
-    feature = "stm32l4x6",
-))]
-use crate::gpio::gpiob::{PB10, PB11, PB6};
-
-use crate::gpio::gpiob::PB7;
+use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 
 #[cfg(any(feature = "stm32l4x3", feature = "stm32l4x5"))]
 use crate::gpio::gpioc::{PC0, PC1};
-
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x2",
-    feature = "stm32l4x5",
-    feature = "stm32l4x6",
-))]
-pins!(I2C1, AF4,
-    SCL: [PA9, PB6],
-    SDA: [PA10, PB7]);
-
-#[cfg(any(
-    feature = "stm32l4x1",
-    feature = "stm32l4x2",
-    feature = "stm32l4x5",
-    feature = "stm32l4x6",
-))]
-pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x3", feature = "stm32l4x6"))]
 use crate::gpio::gpiob::PB8;
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
 use crate::gpio::gpiob::{PB13, PB14, PB9};
+
+pins!(I2C1, AF4,
+    SCL: [PA9, PB6],
+    SDA: [PA10, PB7]);
+
+pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
 pins!(I2C1, AF4, SCL: [PB8], SDA: [PB9]);
@@ -572,7 +545,7 @@ pins!(I2C2, AF4, SCL: [PB13], SDA: [PB14]);
 pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);
 
 #[cfg(feature = "stm32l4x3")]
-pins!(I2C1, AF4, SCL: [PB8], SDA: [PB7]);
+pins!(I2C1, AF4, SCL: [PB8], SDA: []);
 
 #[cfg(feature = "stm32l4x3")]
 pins!(I2C2, AF4, SCL: [PC0], SDA: [PC1]);


### PR DESCRIPTION
I've added the i2c Pins for the board I have

I'm not sure this board has `I2C2` or/and `I2C3`, but 2 seemed to behave better in compilation/check?

[Datasheet](https://www.st.com/resource/en/user_manual/dm00387966-stm32-nucleo-64-p-boards-stmicroelectronics.pdf) 
Relevant page: `38`

There must be a more organized way :D

edit: Add page on Datasheet
edit2: reworded everything to reflect current state, now PR is pretty