### PR TITLE
Use CamelCase for gpio::Edge enum variants

### DIFF
--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
             .into_pull_up_input(&mut gpioc.moder, &mut gpioc.pupdr);
         board_btn.make_interrupt_source(&mut dp.SYSCFG, &mut rcc.apb2);
         board_btn.enable_interrupt(&mut dp.EXTI);
-        board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
+        board_btn.trigger_on_edge(&mut dp.EXTI, Edge::Falling);
 
         // Enable interrupts
         unsafe {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -115,14 +115,11 @@ pub struct AF14;
 /// Alternate function 15 (type state)
 pub struct AF15;
 
-// Using SCREAMING_SNAKE_CASE to be consistent with other HALs
-// see 59b2740 and #125 for motivation
-#[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq)]
 pub enum Edge {
-    RISING,
-    FALLING,
-    RISING_FALLING,
+    Rising,
+    Falling,
+    RisingFalling,
 }
 
 /// External Interrupt Pin
@@ -354,15 +351,15 @@ macro_rules! gpio {
                 /// Generate interrupt on rising edge, falling edge or both
                 fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                     match edge {
-                        Edge::RISING => {
+                        Edge::Rising => {
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::FALLING => {
+                        Edge::Falling => {
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::RISING_FALLING => {
+                        Edge::RisingFalling => {
                             exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         }
@@ -699,15 +696,15 @@ macro_rules! gpio {
                     /// Generate interrupt on rising edge, falling edge or both
                     fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                         match edge {
-                            Edge::RISING => {
+                            Edge::Rising => {
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::FALLING => {
+                            Edge::Falling => {
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::RISING_FALLING => {
+                            Edge::RisingFalling => {
                                 exti.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                             }


### PR DESCRIPTION
ref: [h7xx](https://github.com/stm32-rs/stm32h7xx-hal/pull/179), [f1xx](https://github.com/stm32-rs/stm32f1xx-hal/pull/303), [f4xx](https://github.com/stm32-rs/stm32f4xx-hal/pull/250), [f7xx](https://github.com/stm32-rs/stm32f7xx-hal/pull/111)
