### PR TITLE
WIP: Fix ADC support for STM32L47x/L48x

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -13,6 +13,9 @@ use crate::{
     rcc::{AHB2, CCIPR},
 };
 
+// TODO: Only on STM32L47x/L48x.
+use crate::gpio::AnalogPin;
+
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x2", feature = "stm32l4x3",))]
 use pac::ADC as ADC1;
 
@@ -101,7 +104,8 @@ impl ADC {
     }
 }
 
-impl<C> OneShot<ADC, u16, C> for ADC
+// TODO: AnalogPin only on STM32L47x/L48x.
+impl<C: AnalogPin> OneShot<ADC, u16, C> for ADC
 where
     C: Channel,
 {
@@ -125,6 +129,10 @@ where
 
         // Configure channel
         channel.set_sample_time(&self.inner, self.sample_time);
+
+        // TODO: Only on STM32L47x/L48x.
+        // Connect the pin to the ADC
+        channel.connect_adc();
 
         // Select channel
         self.inner.sqr1.write(|w| {
@@ -156,6 +164,10 @@ where
 
         // Read ADC value
         let val = self.inner.dr.read().bits() as u16;
+
+        // TODO: Only on STM32L47x/L48x.
+        // Disconnect the pin from the ADC
+        channel.disconnect_adc();
 
         // Disable ADC
         self.inner.cr.modify(|_, w| w.addis().set_bit());

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -132,6 +132,13 @@ pub trait ExtiPin {
     fn check_interrupt(&mut self) -> bool;
 }
 
+// TODO: Only on STM32L47x/L48x.
+/// Analog Pin
+pub trait AnalogPin {
+    fn connect_adc(&mut self);
+    fn disconnect_adc(&mut self);
+}
+
 macro_rules! doc_comment {
     ($x:expr, $($tt:tt)*) => {
         #[doc = $x]
@@ -187,6 +194,9 @@ macro_rules! gpio {
                 Floating, GpioExt, Input, OpenDrain, Output, Analog, Edge, ExtiPin,
                 PullDown, PullUp, PushPull, State, Speed,
             };
+
+            // TODO: Only on STM32L47x/L48x.
+            use super::AnalogPin;
 
             /// GPIO parts
             pub struct Parts {
@@ -729,6 +739,17 @@ macro_rules! gpio {
                     /// Reads the interrupt pending bit for this pin
                     fn check_interrupt(&mut self) -> bool {
                         unsafe { ((*EXTI::ptr()).pr1.read().bits() & (1 << $i)) != 0 }
+                    }
+                }
+
+                // TODO: Only on STM32L47x/L48x.
+                impl AnalogPin for $PXi<Analog> {
+                    fn connect_adc(&mut self) {
+                        unsafe { (*$GPIOX::ptr()).ascr.modify(|r, w| w.bits(r.bits() | (1 << $i))); }
+                    }
+
+                    fn disconnect_adc(&mut self) {
+                        unsafe { (*$GPIOX::ptr()).ascr.modify(|r, w| w.bits(r.bits() & !(1 << $i))); }
                     }
                 }
 


### PR DESCRIPTION
## Rationale

The current ADC implementation does not support STM32L47x and STM43L78x families. On MCUs from these families, you need to set a bit in the GPIOx_ASCR register to connect the pin to the ADC internally. This pull request adds support for these families.

## Current issues

This PR does not feature-gate the use of the GPIOx_ASCR register, thus making the fix incompatible with other MCUs. The current feature-gating schema is not adapted for such cases, as stated in #29.

## Design questions

To allow pin connection to the ADC, I have added an `AnalogPin` trait with `connect_adc` and `disconnect_adc` functions that I call in the ADC implementation. Do you think it is the way to go, or should I modify the registers directly in the ADC implementation code?