### PR TITLE
Implement RngCore for Rng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ stm32l4 = "0.13.0"
 as-slice = "0.1"
 generic-array = "0.13"
 
+[dependencies.rand_core]
+version = "0.6.2"
+default-features = false
+
 [dependencies.cast]
 version  = "0.2.2"
 default-features = false

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -4,7 +4,7 @@ use core::cmp;
 
 use crate::rcc::{Clocks, AHB2};
 use crate::stm32::RNG;
-use rand_core::{impls, RngCore};
+pub use rand_core::RngCore;
 
 /// Extension trait to activate the RNG
 pub trait RngExt {
@@ -98,11 +98,11 @@ impl RngCore for Rng {
     }
 
     fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+        rand_core::impls::next_u64_via_u32(self)
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_next(self, dest)
+        rand_core::impls::fill_bytes_via_next(self, dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -4,6 +4,7 @@ use core::cmp;
 
 use crate::rcc::{Clocks, AHB2};
 use crate::stm32::RNG;
+use rand_core::{impls, RngCore};
 
 /// Extension trait to activate the RNG
 pub trait RngExt {
@@ -88,6 +89,24 @@ impl Rng {
     // RNG_DR
     pub fn possibly_invalid_random_data(&self) -> u32 {
         self.rng.dr.read().rndata().bits()
+    }
+}
+
+impl RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.get_random_data()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_u32(self)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_next(self, dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        Ok(self.fill_bytes(dest))
     }
 }
 


### PR DESCRIPTION
This PR implements the RngCore trait for the RNG

This trait is used for a more general of an implementation of RNGs, making the RNG more compatible with other projects that accept RngCore structs for providing randomness