### PR TITLE
Add an unsafe and unchecked constructor to DelayCM

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -101,6 +101,14 @@ impl DelayCM {
             sysclk: clocks.sysclk(),
         }
     }
+
+    /// Create a new delay that is unchecked. The user needs to know the `sysclk`.
+    ///
+    /// # Safety
+    /// Sysclk must be the same as the actual clock frequency of the chip
+    pub unsafe fn new_unchecked(sysclk: Hertz) -> Self {
+        DelayCM { sysclk }
+    }
 }
 
 impl DelayMs<u32> for DelayCM {


### PR DESCRIPTION
 This PR adds an unsafe and unchecked constructor function to DelayCM.

This can be used when you wish to have a DelayCM without setting up the chip's clocks. Useful in situations where the chip's default clock speed is used for some tasks that must be completed before the operational clock speed is configured.