### PR TITLE
Lp timers monotonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ usbd-serial = "0.1.0"
 heapless = "0.5"
 cortex-m-rtic = "0.5.5"
 
+[dependencies.rtic-monotonic]
+version = "0.1.0-alpha.0"
+
 [dev-dependencies.panic-rtt-target]
 version  = "0.1.1"
 features = ["cortex-m"]

--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -4,6 +4,8 @@ use rtic_monotonic::{embedded_time, Clock, Fraction, Instant, Monotonic};
 
 use crate::rcc::{Clocks, APB1R1, APB1R2, CCIPR};
 
+use crate::rcc::{Clocks, APB1R1, APB1R2, CCIPR};
+
 use crate::stm32::{LPTIM1, LPTIM2, RCC};
 
 /// Clock sources available for timers

--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -4,8 +4,6 @@ use rtic_monotonic::{embedded_time, Clock, Fraction, Instant, Monotonic};
 
 use crate::rcc::{Clocks, APB1R1, APB1R2, CCIPR};
 
-use crate::rcc::{Clocks, APB1R1, APB1R2, CCIPR};
-
 use crate::stm32::{LPTIM1, LPTIM2, RCC};
 
 /// Clock sources available for timers


### PR DESCRIPTION
An amendment to my previous PR: the mutability of some functions was incorrect. In order to fix it, `is_event_triggered` no longer clears the interrupt flag.