### PR TITLE
Restart continuous mode after disabling and enabling the peripheral

### DIFF
--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -129,6 +129,11 @@ macro_rules! hal {
                 self.lptim.cr.modify(|_, w| w.enable().bit(enabled));
             }
 
+            #[inline(always)]
+            fn start_continuous_mode(&mut self) {
+                self.lptim.cr.modify(|_, w| w.cntstrt().set_bit());
+            }
+
             /// Consume the LPTIM and produce a LowPowerTimer that encapsulates
             /// said LPTIM.
             ///
@@ -197,7 +202,7 @@ macro_rules! hal {
                 instance.enable();
 
                 // Write compare, arr, and continous mode start register _after_ enabling lptim
-                instance.lptim.cr.modify(|_, w| w.cntstrt().set_bit());
+                instance.start_continuous_mode();
 
                 // This operation is sound as arr_value is a u16, and there are 16 writeable bits
                 instance
@@ -219,6 +224,7 @@ macro_rules! hal {
                     Event::AutoReloadMatch => w.arrmie().set_bit(),
                 });
                 self.enable();
+                self.start_continuous_mode();
             }
 
             /// Disable interrupts for the specified event
@@ -230,6 +236,7 @@ macro_rules! hal {
                     Event::AutoReloadMatch => w.arrmie().clear_bit(),
                 });
                 self.enable();
+                self.start_continuous_mode();
             }
 
             /// Check if the specified event has been triggered for this LowPowerTimer.


### PR DESCRIPTION
Fix that continuous mode is not restarted after disabling the peripheral (I had missed that setting `enable` to zero also clears the continuous mode bit)