### PR TITLE
Experimental support for USB OTG FS for L4x5 and L4x6 lines.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,7 @@ required-features = ["rt"]
 [[example]]
 name = "usb_serial"
 required-features = ["rt", "stm32l4x2", "stm32-usbd"]
+
+[[example]]
+name = "otg_fs_serial"
+required-features = ["rt", "stm32l4x6", "otg_fs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ version = "0.5.0"
 features = ["ram_access_2x16"]
 optional = true
 
+[dependencies.synopsys-usb-otg]
+version = "0.2.4"
+features = ["cortex-m", "fs"]
+optional = true
+
 [package.metadata.docs.rs]
 features = ["rt", "stm32l4x2", "stm32-usbd"]
 
@@ -61,6 +66,7 @@ stm32l4x3 = ["stm32l4/stm32l4x3"]
 stm32l4x5 = ["stm32l4/stm32l4x5"]
 stm32l4x6 = ["stm32l4/stm32l4x6"]
 unproven = ["embedded-hal/unproven"]
+otg_fs = ["synopsys-usb-otg"]
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/examples/otg_fs_serial.rs
+++ b/examples/otg_fs_serial.rs
@@ -7,11 +7,13 @@
 extern crate panic_semihosting;
 
 use cortex_m_rt::entry;
-use stm32l4xx_hal::stm32::{RCC, CRS, PWR, Peripherals};
-use stm32l4xx_hal::rcc::{PllConfig, PllDivider, PllSource, MsiFreq, CrystalBypass, ClockSecuritySystem};
 use stm32l4xx_hal::gpio::Speed;
-use stm32l4xx_hal::otg_fs::{USB, UsbBus};
+use stm32l4xx_hal::otg_fs::{UsbBus, USB};
 use stm32l4xx_hal::prelude::*;
+use stm32l4xx_hal::rcc::{
+    ClockSecuritySystem, CrystalBypass, MsiFreq, PllConfig, PllDivider, PllSource,
+};
+use stm32l4xx_hal::stm32::{Peripherals, CRS, PWR, RCC};
 use usb_device::prelude::*;
 
 /// Enable CRS (Clock Recovery System)

--- a/examples/otg_fs_serial.rs
+++ b/examples/otg_fs_serial.rs
@@ -1,0 +1,197 @@
+//! OTG USB 2.0 FS serial port example using polling in a busy loop.
+//!
+//! Note: Must build with features "stm32l4x5 otg_fs" or "stm32l4x6 otg_fs".
+#![no_main]
+#![no_std]
+
+extern crate panic_semihosting;
+
+use cortex_m_rt::entry;
+use stm32l4xx_hal::stm32::{RCC, CRS, PWR, Peripherals};
+use stm32l4xx_hal::rcc::{PllConfig, PllDivider, PllSource, MsiFreq, CrystalBypass, ClockSecuritySystem};
+use stm32l4xx_hal::gpio::Speed;
+use stm32l4xx_hal::otg_fs::{USB, UsbBus};
+use stm32l4xx_hal::prelude::*;
+use usb_device::prelude::*;
+
+/// Enable CRS (Clock Recovery System)
+fn enable_crs() {
+    let rcc = unsafe { &(*RCC::ptr()) };
+    rcc.apb1enr1.modify(|_, w| w.crsen().set_bit());
+    let crs = unsafe { &(*CRS::ptr()) };
+    // Initialize clock recovery
+    // Set autotrim enabled.
+    crs.cr.modify(|_, w| w.autotrimen().set_bit());
+    // Enable CR
+    crs.cr.modify(|_, w| w.cen().set_bit());
+}
+
+/// Enables VddUSB power supply
+fn enable_usb_pwr() {
+    // Enable PWR peripheral
+    let rcc = unsafe { &(*RCC::ptr()) };
+    rcc.apb1enr1.modify(|_, w| w.pwren().set_bit());
+
+    // Enable VddUSB
+    let pwr = unsafe { &*PWR::ptr() };
+    pwr.cr2.modify(|_, w| w.usv().set_bit());
+}
+
+/// Reset peripherals to known state.
+unsafe fn reset_peripherals(dp: &Peripherals) {
+    dp.RCC.cr.modify(|_, w| w.msion().set_bit());
+    dp.RCC.cfgr.modify(|_, w| {
+        w.sw().bits(0);
+        w.hpre().bits(0);
+        w.ppre1().bits(0);
+        w.ppre2().bits(0);
+        w.mcosel().bits(0);
+        w
+    });
+    dp.RCC.cr.modify(|_, w| {
+        w.pllsai2on().clear_bit();
+        w.pllsai1on().clear_bit();
+        w.pllon().clear_bit();
+        w.hsion().clear_bit();
+        w.csson().clear_bit();
+        w.hseon().clear_bit();
+        w
+    });
+    dp.RCC.pllcfgr.modify(|_, w| {
+        w.pllpdiv().bits(0);
+        w.pllr().bits(0);
+        w.pllren().clear_bit();
+        w.pllq().bits(0);
+        w.pllqen().clear_bit();
+        w.pllp().clear_bit();
+        w.pllpen().clear_bit();
+        w.plln().bits(1 << 4);
+        w.pllm().bits(0);
+        w.pllsrc().bits(0);
+        w
+    });
+
+    dp.RCC.crrcr.modify(|_, w| w.hsi48on().clear_bit());
+    dp.RCC.cr.modify(|_, w| w.hsebyp().clear_bit());
+
+    dp.RCC.pllcfgr.modify(|_, w| {
+        w.pllsrc().bits(0);
+        w.pllpdiv().bits(0);
+        w
+    });
+
+    dp.RCC.cier.reset();
+
+    dp.FLASH.acr.modify(|_, w| w.bits(4));
+}
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+unsafe fn main() -> ! {
+    let dp = Peripherals::take().unwrap();
+
+    //reset_peripherals(&dp);
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
+
+    // Set to true if external 16 MHz high-speed resonator/crystal is used.
+    const USE_HSE_CLK: bool = true;
+
+    let clocks = {
+        if !USE_HSE_CLK {
+            // 48 MHz / 6 * 40 / 4 = 80 MHz
+            let pll_cfg = PllConfig::new(6, 40, PllDivider::Div4);
+
+            // Note: If program needs low-speed clocks, adjust this.
+            rcc.cfgr
+                .msi(MsiFreq::RANGE48M) // Set the MSI (multi-speed internal) clock to 48 MHz
+                .pll_source(PllSource::MSI)
+                .sysclk_with_pll(80.mhz(), pll_cfg)
+                .pclk1(24.mhz())
+                .pclk2(24.mhz())
+                .freeze(&mut flash.acr, &mut pwr)
+        } else {
+            // Note: If program needs low-speed clocks, adjust this.
+            //       Tested using a 16 MHz resonator.
+            rcc.cfgr
+                .msi(MsiFreq::RANGE48M)
+                .hse(
+                    16.mhz(),
+                    CrystalBypass::Disable, // Bypass enabled when clock signals instead of crystals/resonators are used.
+                    ClockSecuritySystem::Disable, // We have not set up interrupt routines handling clock drifts/errors.
+                )
+                .pll_source(PllSource::HSE)
+                .sysclk(80.mhz())
+                .freeze(&mut flash.acr, &mut pwr)
+        }
+    };
+
+    // Enable clock recovery system.
+    enable_crs();
+    // Enable USB power (and disable VddUSB power isolation).
+    enable_usb_pwr();
+
+    let mut gpioa = dp.GPIOA.split(&mut rcc.ahb2);
+
+    let usb = USB {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        hclk: clocks.hclk(),
+        pin_dm: gpioa
+            .pa11
+            .into_af10(&mut gpioa.moder, &mut gpioa.afrh)
+            .set_speed(Speed::VeryHigh),
+        pin_dp: gpioa
+            .pa12
+            .into_af10(&mut gpioa.moder, &mut gpioa.afrh)
+            .set_speed(Speed::VeryHigh),
+    };
+
+    let usb_bus = UsbBus::new(usb, &mut EP_MEMORY);
+
+    let mut usb_serial = usbd_serial::SerialPort::new(&usb_bus);
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .manufacturer("Fake Company")
+        .product("Serial port")
+        .serial_number("TEST")
+        .device_class(usbd_serial::USB_CLASS_CDC)
+        .build();
+
+    #[cfg(feature = "semihosting")]
+    hprintln!("Polling!").ok();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut usb_serial]) {
+            continue;
+        }
+
+        let mut buf = [0u8; 64];
+
+        match usb_serial.read(&mut buf) {
+            Ok(count) if count > 0 => {
+                // Echo back in upper case
+                for c in buf[0..count].iter_mut() {
+                    if 0x61 <= *c && *c <= 0x7a {
+                        *c &= !0x20;
+                    }
+                }
+
+                let mut write_offset = 0;
+                while write_offset < count {
+                    match usb_serial.write(&buf[write_offset..count]) {
+                        Ok(len) if len > 0 => {
+                            write_offset += len;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,10 @@ pub mod gpio;
     feature = "stm32l4x6"
 ))]
 pub mod i2c;
+#[cfg(all(feature = "otg_fs",
+          any(feature = "stm32l4x5", feature = "stm32l4x6")
+))]
+pub mod otg_fs;
 #[cfg(any(
     feature = "stm32l4x1",
     feature = "stm32l4x2",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,7 @@ pub mod gpio;
     feature = "stm32l4x6"
 ))]
 pub mod i2c;
-#[cfg(all(feature = "otg_fs",
-          any(feature = "stm32l4x5", feature = "stm32l4x6")
-))]
+#[cfg(all(feature = "otg_fs", any(feature = "stm32l4x5", feature = "stm32l4x6")))]
 pub mod otg_fs;
 #[cfg(any(
     feature = "stm32l4x1",

--- a/src/otg_fs.rs
+++ b/src/otg_fs.rs
@@ -1,0 +1,54 @@
+//! USB OTG full-speed peripheral
+//!
+//! The STM32L4 series only supports the full-speed peripheral.
+
+use crate::stm32;
+
+use crate::gpio::{
+    gpioa::{PA11, PA12},
+    Alternate, Floating, Input, AF10,
+};
+use crate::time::Hertz;
+
+pub use synopsys_usb_otg::UsbBus;
+use synopsys_usb_otg::UsbPeripheral;
+
+pub struct USB {
+    pub usb_global: stm32::OTG_FS_GLOBAL,
+    pub usb_device: stm32::OTG_FS_DEVICE,
+    pub usb_pwrclk: stm32::OTG_FS_PWRCLK,
+    pub pin_dm: PA11<Alternate<AF10, Input<Floating>>>,
+    pub pin_dp: PA12<Alternate<AF10, Input<Floating>>>,
+    pub hclk: Hertz,
+}
+
+unsafe impl Sync for USB {}
+
+unsafe impl UsbPeripheral for USB {
+    const REGISTERS: *const () = stm32::OTG_FS_GLOBAL::ptr() as *const ();
+
+    const HIGH_SPEED: bool = false;
+    const FIFO_DEPTH_WORDS: usize = 320;
+
+    const ENDPOINT_COUNT: usize = 6;
+
+    fn enable() {
+        let rcc = unsafe { &*stm32::RCC::ptr() };
+
+        cortex_m::interrupt::free(|_| {
+            // Enable USB peripheral
+            rcc.ahb2enr.modify(|_, w| w.otgfsen().set_bit());
+            let _ = rcc.ahb2enr.read().otgfsen().bit_is_set();
+
+            // Reset USB peripheral
+            rcc.ahb2rstr.modify(|_, w| w.otgfsrst().set_bit());
+            rcc.ahb2rstr.modify(|_, w| w.otgfsrst().clear_bit());
+        });
+    }
+
+    fn ahb_frequency_hz(&self) -> u32 {
+        self.hclk.0
+    }
+}
+
+pub type UsbBusType = UsbBus<USB>;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -778,7 +778,8 @@ impl CFGR {
 
         // MSI always starts on reset
         if self.msi.is_none() {
-            rcc.cr.modify(|_, w| w.msion().clear_bit().msipllen().clear_bit())
+            rcc.cr
+                .modify(|_, w| w.msion().clear_bit().msipllen().clear_bit())
         }
 
         //

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -778,8 +778,7 @@ impl CFGR {
 
         // MSI always starts on reset
         if self.msi.is_none() {
-            rcc.cr
-                .modify(|_, w| w.msion().clear_bit().msipllen().clear_bit())
+            rcc.cr.modify(|_, w| w.msion().clear_bit().msipllen().clear_bit())
         }
 
         //


### PR DESCRIPTION
The STM32L4 series are available in different lines:
  - STM32L4x1: Access Line.
  - STM32L4x2: USB Device.
  - STM32L4x3: USB Device, LCD.
  - STM32L4x5: USB OTG 2.0.
  - STM32L4x6: USB OTG 2.0, LCD.

USB OTG is implemented by the Synopsys USB library (synopsys-usb-otg), which is also used by a number of products in the STM32F-series chips.

This commit adds support for full-speed (FS) USB support for the 4x5 and 4x6 lines.