### PR TITLE
Make I2C1 available on PB8/PB9 combination for stm32l4x2

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -478,8 +478,16 @@ use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
 #[cfg(any(feature = "stm32l4x3", feature = "stm32l4x5", feature = "stm32l4x6"))]
 use crate::gpio::gpioc::{PC0, PC1};
 
-#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x3", feature = "stm32l4x6"))]
+#[cfg(any(
+    feature = "stm32l4x1",
+    feature = "stm32l4x2",
+    feature = "stm32l4x3",
+    feature = "stm32l4x6",
+))]
 use crate::gpio::gpiob::PB8;
+
+#[cfg(feature = "stm32l4x2")]
+use crate::gpio::gpiob::PB9;
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
 use crate::gpio::gpiob::{PB13, PB14, PB9};
@@ -490,7 +498,7 @@ pins!(I2C1, AF4,
 
 pins!(I2C2, AF4, SCL: [PB10], SDA: [PB11]);
 
-#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]
+#[cfg(any(feature = "stm32l4x1", feature = "stm32l4x2", feature = "stm32l4x6"))]
 pins!(I2C1, AF4, SCL: [PB8], SDA: [PB9]);
 
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x6"))]


### PR DESCRIPTION
See title.

The current way these feature gates are laid out make it somewhat difficult to keep a good oversight of what's what. 

Perhaps this is something that could be rethought/cleaned up a little in the future. My suggestion would be a feature gated module that is `pub use`d in the actual i2c module for each part, so that it is clear what belongs where. With such a solution, we'd add slightly extra source code, but it would be clear which use statements are required where, and how to change it.

I will most likely work up a PR to do just that during the weekend.