### PR TITLE
Fix I2C pin inconsistency, pin-completeness, and add I2C4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,3 +125,7 @@ required-features = ["rt"]
 [[example]]
 name = "usb_serial"
 required-features = ["rt", "stm32l4x2", "stm32-usbd"]
+
+[[example]]
+name = "i2c_write"
+required-features = ["stm32l4x1"]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -149,6 +149,10 @@ hal!(I2C1, enr, rstr, i2c1, i2c1en, i2c1rst);
 hal!(I2C2, enr, rstr, i2c2, i2c2en, i2c2rst);
 hal!(I2C3, enr, rstr, i2c3, i2c3en, i2c3rst);
 
+// This peripheral is not present on
+// STM32L471XX and STM32L431XX
+// STM32L432XX and STM32l442XX
+// STM32L486XX and STM32L476XX
 #[cfg(any(feature = "stm32l4x1", feature = "stm32l4x2", feature = "stm32l4x6"))]
 hal!(I2C4, enr2, rstr2, i2c4, i2c4en, i2c4rst);
 
@@ -484,17 +488,17 @@ mod stm32l4x1_pins {
 
     pins!(I2C1, AF4, SCL: [PB6, PB8], SDA: [PB7, PB9]);
 
-    // Not on STM32L471xx
+    // Not on STM32L471XX
     pins!(I2C1, AF4, SCL: [PA9], SDA: [PA10]);
 
     pins!(I2C2, AF4, SCL: [PB10, PB13], SDA: [PB11, PB14]);
 
     pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);
 
-    // Not on STM32L471xx
+    // Not on STM32L471XX
     pins!(I2C3, AF4, SCL: [PA7], SDA: [PB4]);
 
-    // Both only on STM32L451XX
+    // Not on STM32L471XX and STM32L431XX
     pins!(I2C4, AF4, SCL: [PD12], SDA: [PD13]);
     pins!(I2C4, AF3, SCL: [PB10], SDA: [PB11]);
 }
@@ -517,7 +521,8 @@ mod stm32l4x2_pins {
     // Technically not present on STM32L432XX and STM32l442XX (pins missing from ref. manual)
     pins!(I2C3, AF4, SCL: [PC0], SDA: [PC1]);
 
-    // All three only on STM32l452XX and STM32l462XX
+    // Technically not present on STM32L432XX and STM32l442XX (pins missing from ref. manual)
+    // Not present on STM32L412XX and STM32L422XX
     pins!(I2C4, AF2, SCL: [PC0], SDA: [PC1]);
     pins!(I2C4, AF3, SCL: [PB10], SDA: [PB11]);
     pins!(I2C4, AF4, SCL: [PD12], SDA: [PD13]);

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -255,6 +255,16 @@ impl APB1R1 {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1rstr1 }
     }
+
+    pub(crate) fn enr2(&mut self) -> &rcc::APB1ENR2 {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb1enr2 }
+    }
+
+    pub(crate) fn rstr2(&mut self) -> &rcc::APB1RSTR2 {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb1rstr2 }
+    }
 }
 
 /// Advanced Peripheral Bus 1 (APB1) register 2 registers

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -256,11 +256,13 @@ impl APB1R1 {
         unsafe { &(*RCC::ptr()).apb1rstr1 }
     }
 
+    #[cfg(not(any(feature = "stm32l4x3", feature = "stm32l4x5")))]
     pub(crate) fn enr2(&mut self) -> &rcc::APB1ENR2 {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1enr2 }
     }
 
+    #[cfg(not(any(feature = "stm32l4x3", feature = "stm32l4x5")))]
     pub(crate) fn rstr2(&mut self) -> &rcc::APB1RSTR2 {
         // NOTE(unsafe) this proxy grants exclusive access to this register
         unsafe { &(*RCC::ptr()).apb1rstr2 }


### PR DESCRIPTION
This PR includes some changes to the way I2C pins are assigned, adds all of the missing ones, and adds I2C4 for those parts that have it.

Some `unwrap` calls were removed in favor of `match` statements with `panic`s. Not sure if `panic`ing is the right thing to do, but at least it doesn't draw in format bloat. 

Instead of having combined, feature gated `use`s and `pin!` calls I've split up the pins available for each family into their own submodule. It's a bit less neat (there's quite a bit of repetition), but due to the big differences per family and within families, I think it would be more logical to split it out like this. It makes it a lot easier to see what's where, which is more important in this case as it improves maintainability of this relatively unchanging part of the HAL quite a bit, IMO.

It's far from perfect, sadly, as there are some parts within families that have more/fewer I2C peripherals, or some pins have different or missing functions within families. There's not much to do about that, as the current feature set doesn't allow us to differentiate between parts within a family. I've split out and added comments to the pins/peripherals where this is the case. 

Additionally, it seems that the STM32L4X6 family has `gpioh` pins, but the PAC doesn't provide these. 

I'm not sure if the design makes sense in this state, but at least there's an overview of which parts have what pins for which functions, so it can at least be used for guidance purposes.

Fixes https://github.com/stm32-rs/stm32l4xx-hal/issues/130 and fixes https://github.com/stm32-rs/stm32l4xx-hal/issues/43
