### PR TITLE
Fix incorrect SDA and SCL for i2c

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -513,8 +513,9 @@ mod stm32l4x2_pins {
 
     pins!(I2C1, AF4, SCL: [PA9, PB6], SDA: [PA10, PB7]);
 
-    // Technically not present on STM32L432XX and STM32l442XX (pins missing from ref. manual)
-    pins!(I2C2, AF4, SCL: [PB8, PB10, PB13], SDA: [PB9, PB11, PB14]);
+    // Both technically not present on STM32L432XX and STM32l442XX (pins missing from ref. manual)
+    pins!(I2C1, AF4, SCL: [PB8], SDA: [PB9]);
+    pins!(I2C2, AF4, SCL: [PB10, PB13], SDA: [PB11, PB14]);
 
     pins!(I2C3, AF4, SCL: [PA7], SDA: [PB4]);
 


### PR DESCRIPTION
I accidentally added pins B8 and B9 to I2C2 for stm32l4x2 parts, while they are for I2C1