### PR TITLE
ADC Interrupt and DMA support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,3 +152,7 @@ required-features = ["stm32l4x1"]
 [[example]]
 name = "lptim_rtic"
 required-features = ["rt", "stm32l4x2"]
+
+[[example]]
+name = "adc_dma"
+required-features = ["rt", "stm32l4x1"]

--- a/examples/adc_dma.rs
+++ b/examples/adc_dma.rs
@@ -1,0 +1,106 @@
+#![no_main]
+#![no_std]
+
+use panic_rtt_target as _;
+use rtt_target::{rprintln, rtt_init_print};
+use stm32l4xx_hal::{
+    adc::{DmaMode, SampleTime, Sequence, ADC},
+    delay::DelayCM,
+    dma::{dma1, RxDma, Transfer, W},
+    prelude::*,
+    time::Hertz,
+};
+
+use rtic::app;
+
+const SEQUENCE_LEN: usize = 3;
+
+#[app(device = stm32l4xx_hal::stm32, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
+const APP: () = {
+    // RTIC app is written in here!
+
+    struct Resources {
+        transfer: Option<Transfer<W, &'static mut [u16; SEQUENCE_LEN], RxDma<ADC, dma1::C1>>>,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> init::LateResources {
+        let MEMORY = {
+            static mut MEMORY: [u16; SEQUENCE_LEN] = [0u16; SEQUENCE_LEN];
+            unsafe { &mut MEMORY }
+        };
+
+        rtt_init_print!();
+
+        rprintln!("Hello from init!");
+
+        let cp = cx.core;
+        let mut dcb = cp.DCB;
+        let mut dwt = cp.DWT;
+
+        dcb.enable_trace();
+        dwt.enable_cycle_counter();
+
+        let pac = cx.device;
+
+        let mut rcc = pac.RCC.constrain();
+        let mut flash = pac.FLASH.constrain();
+        let mut pwr = pac.PWR.constrain(&mut rcc.apb1r1);
+        let dma_channels = pac.DMA1.split(&mut rcc.ahb1);
+
+        //
+        // Initialize the clocks
+        //
+        let clocks = rcc
+            .cfgr
+            .sysclk(Hertz(80_000_000))
+            .freeze(&mut flash.acr, &mut pwr);
+
+        let mut delay = DelayCM::new(clocks);
+
+        let mut adc = ADC::new(
+            pac.ADC1,
+            pac.ADC_COMMON,
+            &mut rcc.ahb2,
+            &mut rcc.ccipr,
+            &mut delay,
+        );
+
+        let mut temp_pin = adc.enable_temperature();
+
+        let dma1_channel = dma_channels.1;
+
+        adc.configure_sequence(&mut temp_pin, Sequence::One, SampleTime::Cycles12_5);
+        adc.configure_sequence(&mut temp_pin, Sequence::Two, SampleTime::Cycles247_5);
+        adc.configure_sequence(&mut temp_pin, Sequence::Three, SampleTime::Cycles640_5);
+
+        // Heapless boxes also work very well as buffers for DMA transfers
+        let transfer = Transfer::from_adc(adc, dma1_channel, MEMORY, DmaMode::Oneshot, true);
+
+        init::LateResources {
+            transfer: Some(transfer),
+        }
+    }
+
+    #[idle]
+    fn idle(_cx: idle::Context) -> ! {
+        loop {
+            cortex_m::asm::nop();
+        }
+    }
+
+    #[task(binds = DMA1_CH1, resources = [transfer])]
+    fn dma1_interrupt(cx: dma1_interrupt::Context) {
+        let transfer = cx.resources.transfer;
+        if let Some(transfer_val) = transfer.take() {
+            let (buffer, rx_dma) = transfer_val.wait();
+            rprintln!("DMA measurements: {:?}", buffer);
+            *transfer = Some(Transfer::from_adc_dma(
+                rx_dma,
+                buffer,
+                DmaMode::Oneshot,
+                true,
+            ));
+        }
+    }
+};

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -257,10 +257,10 @@ impl ADC {
     }
 
     // DMA channels:
-    //  ADC1: DMA2_3 with CxS 0000
-    //  ADC2: DMA2_4 with CxS 0000
-    //  ADC1: DMA1_1 with CxS 0000
-    //  ADC2: DMA1_2 with CxS 0000
+    //  ADC1: DMA2_3 with C2S 0000
+    //  ADC2: DMA2_4 with C2S 0000
+    //  ADC1: DMA1_1 with C1S 0000 (implemented)
+    //  ADC2: DMA1_2 with C1S 0000
 
     pub fn get_data(&self) -> u16 {
         // Sound, as bits 31:16 are reserved, read-only and 0 in ADC_DR

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -316,13 +316,27 @@ impl ADC {
 
     /// Get the configured sequence length (= `actual sequence length - 1`)
     pub(crate) fn get_sequence_length(&self) -> u8 {
-        self.adc.sqr1.read().l3().bits()
+        #[cfg(not(feature = "stm32l4x6"))]
+        {
+            self.adc.sqr1.read().l3().bits()
+        }
+        #[cfg(feature = "stm32l4x6")]
+        {
+            self.adc.sqr1.read().l().bits()
+        }
     }
 
     /// Private: length must be `actual sequence length - 1`, so not API-friendly.
     /// Use [`ADC::reset_sequence`] and [`ADC::configure_sequence`] instead
     fn set_sequence_length(&mut self, length: u8) {
-        self.adc.sqr1.modify(|_, w| unsafe { w.l3().bits(length) });
+        #[cfg(not(feature = "stm32l4x6"))]
+        {
+            self.adc.sqr1.modify(|_, w| unsafe { w.l3().bits(length) });
+        }
+        #[cfg(feature = "stm32l4x6")]
+        {
+            self.adc.sqr1.modify(|_, w| unsafe { w.l().bits(length) });
+        }
     }
 
     /// Reset the sequence length to 1
@@ -330,7 +344,14 @@ impl ADC {
     /// Does *not* erase previously configured sequence settings, only
     /// changes the sequence length
     pub fn reset_sequence(&mut self) {
-        self.adc.sqr1.modify(|_, w| unsafe { w.l3().bits(0b0000) })
+        #[cfg(not(feature = "stm32l4x6"))]
+        {
+            self.adc.sqr1.modify(|_, w| unsafe { w.l3().bits(0b0000) })
+        }
+        #[cfg(feature = "stm32l4x6")]
+        {
+            self.adc.sqr1.modify(|_, w| unsafe { w.l().bits(0b0000) })
+        }
     }
 
     pub fn has_completed_conversion(&self) -> bool {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -37,7 +37,8 @@ pub struct ADC {
 pub enum DmaMode {
     Disabled = 0,
     Oneshot = 1,
-    Circular = 2,
+    // FIXME: Figure out how to get circular DMA to function properly (requires circbuffer?)
+    // Circular = 2,
 }
 
 #[derive(PartialEq, PartialOrd, Clone, Copy)]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,8 +1,13 @@
 //! # Analog to Digital converter
 
-use core::convert::Infallible;
+use core::{
+    convert::Infallible,
+    ops::DerefMut,
+    sync::atomic::{self, Ordering},
+};
 
 use crate::{
+    dma::{dma1, Event as DMAEvent, RxDma, Transfer, TransferPayload, W},
     gpio::{self, Analog},
     hal::{
         adc::{Channel as EmbeddedHalChannel, OneShot},
@@ -14,6 +19,7 @@ use crate::{
 };
 
 use pac::{ADC1, ADC_COMMON};
+use stable_deref_trait::StableDeref;
 
 /// Vref internal signal, used for calibration
 pub struct Vref;
@@ -449,6 +455,108 @@ where
         self.disable();
 
         Ok(val)
+    }
+}
+
+impl TransferPayload for RxDma<ADC, dma1::C1> {
+    fn start(&mut self) {
+        self.channel.start();
+    }
+
+    fn stop(&mut self) {
+        self.channel.stop();
+    }
+}
+
+impl RxDma<ADC, dma1::C1> {
+    pub fn split(mut self) -> (ADC, dma1::C1) {
+        self.stop();
+        (self.payload, self.channel)
+    }
+}
+
+impl<BUFFER, const N: usize> Transfer<W, BUFFER, RxDma<ADC, dma1::C1>>
+where
+    BUFFER: Sized + StableDeref<Target = [u16; N]> + DerefMut + 'static,
+{
+    pub fn from_adc_dma(
+        dma: RxDma<ADC, dma1::C1>,
+        buffer: BUFFER,
+        dma_mode: DmaMode,
+        transfer_complete_interrupt: bool,
+    ) -> Self {
+        let (adc, channel) = dma.split();
+        Transfer::from_adc(adc, channel, buffer, dma_mode, transfer_complete_interrupt)
+    }
+
+    /// Initiate a new DMA transfer from an ADC.
+    ///
+    /// `dma_mode` indicates the desired mode for DMA.
+    ///
+    /// If `transfer_complete_interrupt` is true, the transfer
+    /// complete interrupt (= `DMA1_CH1`) will be enabled
+    pub fn from_adc(
+        mut adc: ADC,
+        mut channel: dma1::C1,
+        buffer: BUFFER,
+        dma_mode: DmaMode,
+        transfer_complete_interrupt: bool,
+    ) -> Self {
+        assert!(dma_mode != DmaMode::Disabled);
+
+        let (enable, circular) = match dma_mode {
+            DmaMode::Disabled => (false, false),
+            DmaMode::Oneshot => (true, false),
+        };
+
+        adc.adc
+            .cfgr
+            .modify(|_, w| w.dmaen().bit(enable).dmacfg().bit(circular));
+
+        channel.set_peripheral_address(&adc.adc.dr as *const _ as u32, false);
+
+        // SAFETY: since the length of BUFFER is known to be `N`, we are allowed
+        // to perform N transfers into said buffer
+        channel.set_memory_address(buffer.as_ptr() as u32, true);
+        channel.set_transfer_length(N as u16);
+
+        channel.cselr().modify(|_, w| w.c1s().bits(0b0000));
+
+        channel.ccr().modify(|_, w| unsafe {
+            w.mem2mem()
+                .clear_bit()
+                // 00: Low, 01: Medium, 10: High, 11: Very high
+                .pl()
+                .bits(0b01)
+                // 00: 8-bits, 01: 16-bits, 10: 32-bits, 11: Reserved
+                .msize()
+                .bits(0b01)
+                // 00: 8-bits, 01: 16-bits, 10: 32-bits, 11: Reserved
+                .psize()
+                .bits(0b01)
+                // Peripheral -> Mem
+                .dir()
+                .clear_bit()
+                .circ()
+                .bit(circular)
+        });
+
+        if transfer_complete_interrupt {
+            channel.listen(DMAEvent::TransferComplete);
+        }
+
+        atomic::compiler_fence(Ordering::Release);
+
+        channel.start();
+        adc.start_conversion();
+
+        Transfer::w(
+            buffer,
+            RxDma {
+                channel,
+                payload: adc,
+            },
+        )
     }
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1047,11 +1047,18 @@ impl<BUFFER, const N: usize> Transfer<W, BUFFER, dma1::C1, ADC>
 where
     BUFFER: Sized + StableDeref<Target = [u16; N]> + DerefMut + 'static,
 {
+    /// Initiate a new DMA transfer from an ADC.
+    ///
+    /// `dma_mode` indicates the desired mode for DMA.
+    ///
+    /// If `transfer_complete_interrupt` is true, the transfer
+    /// complete interrupt (= `DMA1_CH1`) will be enabled
     pub fn from_adc(
         mut adc: ADC,
         mut channel: dma1::C1,
         buffer: BUFFER,
         dma_mode: adc::DmaMode,
+        transfer_complete_interrupt: bool,
     ) -> Self {
         let (enable, circular) = match dma_mode {
             DmaMode::Disabled => (false, false),
@@ -1090,6 +1097,10 @@ where
                 .circ()
                 .bit(circular)
         });
+
+        if transfer_complete_interrupt {
+            channel.listen(Event::TransferComplete);
+        }
 
         atomic::compiler_fence(Ordering::Release);
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -7,11 +7,11 @@ use core::mem::MaybeUninit;
 use core::ops::DerefMut;
 use core::ptr;
 use core::slice;
-use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 use core::{
     fmt,
-    sync::atomic::{self, Ordering, compiler_fence},
+    sync::atomic::{self, compiler_fence, Ordering},
 };
+use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 
 use crate::{
     adc::{self, DmaMode, ADC},

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -2,16 +2,21 @@
 
 #![allow(dead_code)]
 
-use core::fmt;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ops::DerefMut;
 use core::ptr;
 use core::slice;
-use core::sync::atomic::{compiler_fence, Ordering};
-
-use crate::rcc::AHB1;
 use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
+use core::{
+    fmt,
+    sync::atomic::{self, Ordering, compiler_fence},
+};
+
+use crate::{
+    adc::{self, DmaMode, ADC},
+    rcc::AHB1,
+};
 use stable_deref_trait::StableDeref;
 
 #[non_exhaustive]
@@ -1035,6 +1040,67 @@ macro_rules! dma {
                 }
             }
         )+
+    }
+}
+
+impl<BUFFER, const N: usize> Transfer<W, BUFFER, dma1::C1, ADC>
+where
+    BUFFER: Sized + StableDeref<Target = [u16; N]> + DerefMut + 'static,
+{
+    pub fn from_adc(
+        mut adc: ADC,
+        mut channel: dma1::C1,
+        buffer: BUFFER,
+        dma_mode: adc::DmaMode,
+    ) -> Self {
+        let (enable, circular) = match dma_mode {
+            DmaMode::Disabled => (false, false),
+            DmaMode::Oneshot => (true, false),
+            DmaMode::Circular => (true, true),
+        };
+
+        adc.adc
+            .cfgr
+            .modify(|_, w| w.dmaen().bit(enable).dmacfg().bit(circular));
+
+        channel.set_peripheral_address(&adc.adc.dr as *const _ as u32, false);
+
+        // SAFETY: since the length of BUFFER is known to be `N`, we are allowed
+        // to perform N transfers into said buffer
+        channel.set_memory_address(buffer.as_ptr() as u32, true);
+        channel.set_transfer_length(N as u16);
+
+        channel.cselr().modify(|_, w| w.c1s().bits(0b0000));
+
+        channel.ccr().modify(|_, w| unsafe {
+            w.mem2mem()
+                .clear_bit()
+                // 00: Low, 01: Medium, 10: High, 11: Very high
+                .pl()
+                .bits(0b01)
+                // 00: 8-bits, 01: 16-bits, 10: 32-bits, 11: Reserved
+                .msize()
+                .bits(0b01)
+                // 00: 8-bits, 01: 16-bits, 10: 32-bits, 11: Reserved
+                .psize()
+                .bits(0b01)
+                // Peripheral -> Mem
+                .dir()
+                .clear_bit()
+                .circ()
+                .bit(circular)
+        });
+
+        atomic::compiler_fence(Ordering::Release);
+
+        channel.start();
+        adc.start_conversion();
+        Transfer {
+            _mode: PhantomData {},
+            buffer,
+            channel,
+            payload: adc,
+        }
     }
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1085,10 +1085,11 @@ where
         dma_mode: adc::DmaMode,
         transfer_complete_interrupt: bool,
     ) -> Self {
+        assert!(dma_mode != DmaMode::Disabled);
+
         let (enable, circular) = match dma_mode {
             DmaMode::Disabled => (false, false),
             DmaMode::Oneshot => (true, false),
-            DmaMode::Circular => (true, true),
         };
 
         adc.adc


### PR DESCRIPTION
This PR adds support for sequences, interrupts and DMA requests to ADC1 by implementing `from_adc` for the `dma::Transfer` struct.

There is currently a problem with the `L3` (also: `L`) bits in the `SRQ1` register having the incorrect and inconsistent names across the parts. For now, I've feature gated this issue away. This problem is fixed in the latest source of the STM32L4 crate, but the fix has not been released yet.