### PR TITLE
Fix LPTIMx configuration on start

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,6 @@ required-features = ["rt", "stm32l4x6", "otg_fs"]
 name = "i2c_write"
 required-features = ["stm32l4x1"]
 
+[[example]]
+name = "lptim_rtic"
+required-features = ["rt", "stm32l4x2"]

--- a/examples/lptim_rtic.rs
+++ b/examples/lptim_rtic.rs
@@ -1,0 +1,99 @@
+//! Test with
+//! cargo flash --release --features stm32l4x2,rt --chip STM32L452RETx --example lptim_rtic --target thumbv7em-none-eabi
+//! on Nucleo-L452-P board
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+extern crate panic_rtt_target;
+
+use rtt_target::rprintln;
+use stm32l4xx_hal::{
+    flash::ACR,
+    gpio::{gpiob::PB13, Output, PushPull, State},
+    lptimer::{ClockSource, Event, LowPowerTimer, LowPowerTimerConfig, PreScaler},
+    pac::LPTIM1,
+    prelude::*,
+    pwr::Pwr,
+    rcc::{ClockSecuritySystem, Clocks, CrystalBypass, RccExt, CFGR},
+    time::U32Ext,
+};
+
+// this is the LD4 on Nucleo-L452-P
+type Led = PB13<Output<PushPull>>;
+type Timer = LowPowerTimer<LPTIM1>;
+
+pub fn configure_clock_tree(cfgr: CFGR, acr: &mut ACR, pwr: &mut Pwr) -> Clocks {
+    cfgr.lse(CrystalBypass::Disable, ClockSecuritySystem::Disable)
+        .sysclk(80.mhz())
+        .freeze(acr, pwr)
+}
+
+#[rtic::app(device = stm32l4xx_hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        led: Led,
+        lptim: Timer,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        rtt_target::rtt_init_print!();
+
+        rprintln!("Init start");
+        let device = ctx.device;
+        // Configure the clock.
+        let mut rcc = device.RCC.constrain();
+        let mut flash = device.FLASH.constrain();
+        let mut pwr = device.PWR.constrain(&mut rcc.apb1r1);
+        let mut gpiob = device.GPIOB.split(&mut rcc.ahb2);
+        let clocks = configure_clock_tree(rcc.cfgr, &mut flash.acr, &mut pwr);
+
+        // PB13 is a user led on Nucleo-L452-P board
+        let led = gpiob.pb13.into_push_pull_output_with_state(
+            &mut gpiob.moder,
+            &mut gpiob.otyper,
+            State::Low,
+        );
+        rprintln!("Clocks = {:#?}", clocks);
+        let lptim_config = LowPowerTimerConfig::default()
+            .clock_source(ClockSource::LSE)
+            .prescaler(PreScaler::U1)
+            .arr_value(32_768u16); // roughly 1s
+        let mut lptim = LowPowerTimer::lptim1(
+            device.LPTIM1,
+            lptim_config,
+            &mut rcc.apb1r1,
+            &mut rcc.ccipr,
+            clocks,
+        );
+        lptim.listen(Event::AutoReloadMatch);
+        init::LateResources { lptim, led }
+    }
+
+    #[task(binds = LPTIM1, resources = [lptim, led])]
+    fn timer_tick(mut ctx: timer_tick::Context) {
+        let timer_tick::Resources { lptim, led } = ctx.resources;
+        if lptim.is_event_triggered(Event::AutoReloadMatch) {
+            lptim.clear_event_flag(Event::AutoReloadMatch);
+            rprintln!("LPTIM1 tick");
+
+            if led.is_set_high().unwrap() {
+                led.set_low().unwrap();
+            } else {
+                led.set_high().unwrap();
+            }
+        }
+    }
+
+    #[idle]
+    fn idle(_ctx: idle::Context) -> ! {
+        loop {
+            // See https://github.com/probe-rs/probe-rs/issues/350
+            core::hint::spin_loop();
+        }
+    }
+
+    extern "C" {
+        fn LCD();
+    }
+};

--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -263,7 +263,9 @@ macro_rules! hal {
                 // Additionally, the LPTIM peripheral will always be in the enabled state when this code is called
                 self.lptim.cmp.write(|w| unsafe { w.bits(value as u32) });
 
-                // wait for compare register update ok interrupt to be signalled (RM0394 Rev 4, sec. 30.7.1, Bit 4)
+                // wait for compare register update ok interrupt to be signalled
+                // (see RM0394 Rev 4, sec 30.4.10 for further explanation and
+                // sec. 30.7.1, Bit 4 for register field description)
                 while self.lptim.isr.read().cmpok().bit_is_clear() {}
             }
 
@@ -280,7 +282,9 @@ macro_rules! hal {
                     .arr
                     .write(|w| unsafe { w.bits(arr_value as u32) });
 
-                // wait for autoreload write ok interrupt to be signalled (RM0394 Rev 4, sec. 30.7.1, Bit 4)
+                // wait for autoreload write ok interrupt to be signalled
+                // (see RM0394 Rev 4, sec 30.4.10 for further explanation and
+                // sec. 30.7.1, Bit 4 for register field description)
                 while self.lptim.isr.read().arrok().bit_is_clear() {}
             }
 

--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -134,23 +134,6 @@ macro_rules! hal {
                 self.lptim.cr.modify(|_, w| w.cntstrt().set_bit());
             }
 
-            /// Set auto reload register
-            /// has to be used _after_ enabling of lptim
-            #[inline(always)]
-            fn set_arr(&mut self, arr_value: u16) {
-                // clear autoreload register OK interrupt flag
-                self.lptim.icr.write(|w| w.arrokcf().set_bit());
-
-                // Write autoreload value
-                // This operation is sound as arr_value is a u16, and there are 16 writeable bits
-                self.lptim
-                    .arr
-                    .write(|w| unsafe { w.bits(arr_value as u32) });
-
-                // wait for autoreload write ok interrupt to be signalled (RM0394 Rev 4, sec. 30.7.1, Bit 4)
-                while self.lptim.isr.read().arrok().bit_is_clear() {}
-            }
-
             /// Consume the LPTIM and produce a LowPowerTimer that encapsulates
             /// said LPTIM.
             ///
@@ -219,7 +202,7 @@ macro_rules! hal {
                 instance.enable();
 
                 instance.start_continuous_mode();
-                instance.set_arr(arr_value);
+                instance.set_autoreload(arr_value);
                 instance.set_compare_match(compare_value);
                 instance
             }
@@ -282,6 +265,23 @@ macro_rules! hal {
 
                 // wait for compare register update ok interrupt to be signalled (RM0394 Rev 4, sec. 30.7.1, Bit 4)
                 while self.lptim.isr.read().cmpok().bit_is_clear() {}
+            }
+
+            /// Set auto reload register
+            /// has to be used _after_ enabling of lptim
+            #[inline(always)]
+            pub fn set_autoreload(&mut self, arr_value: u16) {
+                // clear autoreload register OK interrupt flag
+                self.lptim.icr.write(|w| w.arrokcf().set_bit());
+
+                // Write autoreload value
+                // This operation is sound as arr_value is a u16, and there are 16 writeable bits
+                self.lptim
+                    .arr
+                    .write(|w| unsafe { w.bits(arr_value as u32) });
+
+                // wait for autoreload write ok interrupt to be signalled (RM0394 Rev 4, sec. 30.7.1, Bit 4)
+                while self.lptim.isr.read().arrok().bit_is_clear() {}
             }
 
             /// Get the current counter value for this LowPowerTimer


### PR DESCRIPTION
After setting autoreload register (LPTIM_ARR) code needs to wait until ARROK field of LPTIM_ISR register is set by hardware to signal the autoreload value was set. For the flag to be set is has to be reset by setting LPTIM_ICR's ARROKCF from possible previous setting. Same fix applied to setting of CMP register.

Also adding example of LPTIM1 usage - simple timer based blinky in RTIC.