### PR TITLE
Use HCLK instead of SYSCLK in DelayUs

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -53,7 +53,7 @@ impl DelayUs<u32> for Delay {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
-        let mut total_rvr = us * (self.clocks.sysclk().0 / 1_000_000);
+        let mut total_rvr = us * (self.clocks.hclk().0 / 1_000_000);
 
         while total_rvr != 0 {
             let current_rvr = if total_rvr <= MAX_RVR {


### PR DESCRIPTION
The SysTick is directly fed by HCLK, so that is the value we must use to
compute the reload value.

This solves issue #152