### PR TITLE
Expose receiver timeout and operation error through FrameReader

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -634,6 +634,18 @@ macro_rules! hal {
                 }
             }
 
+            impl crate::dma::ReceiverTimeout for Rx<pac::$USARTX> {
+                fn check_receiver_timeout(&mut self, clear: bool) -> bool {
+                    self.is_receiver_timeout(clear)
+                }
+            }
+
+            impl crate::dma::OperationError<(), Error> for Rx<pac::$USARTX>{
+                fn check_operation_error(&mut self) -> Result<(), Error> {
+                    self.check_for_error()
+                }
+            }
+
             impl Tx<pac::$USARTX> {
                 pub fn with_dma(self, channel: $dmatxch) -> $txdma {
                     TxDma {


### PR DESCRIPTION
Changing the DMA API resulted in some inconsistencies, which this PR aims to fix.

Before, the type of interrupt that occured could be checked as `FrameSender` did not take ownership over the contained peripheral. With the API change, `FrameSender` takes ownership of `PAYLOAD`, and does not expose any reference to it. This means that we can get a ReceiverTimeout interrupt, but have no way to check that it is actually a receiver timeout.

For the USART, this was fixed by adding an extra trait to check for a specific event, but implementations for checking a receiver timeout and error during operations was lacking. These are added.