### PR TITLE
Pause and resume LPTIMER

### DIFF
--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -300,6 +300,15 @@ macro_rules! hal {
             pub fn get_arr(&self) -> u16 {
                 self.lptim.arr.read().bits() as u16
             }
+
+            pub fn pause(&mut self) {
+                self.disable();
+            }
+
+            pub fn resume(&mut self) {
+                self.enable();
+                self.start_continuous_mode();
+            }
         }
     };
 }


### PR DESCRIPTION
Added function to pause and resume LPTIMER.
When the timer is used for pwm generatoin to drive a speaker there
should be a way to stop the pwm.