### PR TITLE
target hardfp by default.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -27,7 +27,5 @@ rustflags = [
 
 [build]
 # Pick ONE of these compilation targets
-# target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
-target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-# target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+# target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)


### PR DESCRIPTION
L4 is an M4F, so use hardfp ABI by default.
Drop irrelevant targets completely, but leave the commented out option
for people who really insist on using softfp.

Signed-off-by: Karl Palsson <karlp@etactica.com>