### PR TITLE
time: require a type when only milliseconds are supported

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -77,10 +77,10 @@ impl Into<KiloHertz> for MegaHertz {
     }
 }
 
-impl From<u32> for Hertz {
-    fn from(ms: u32) -> Self {
-        if ms <= 1000 {
-            Hertz((1000 + ms / 2) / ms)
+impl From<MilliSeconds> for Hertz {
+    fn from(ms: MilliSeconds) -> Self {
+        if ms.0 <= 1000 {
+            Hertz((1000 + ms.0 / 2) / ms.0)
         } else {
             Hertz(1)
         }


### PR DESCRIPTION
The from method is for milliseconds to Hz conversion, so make sure it
only accepts a milliseconds type, given that it only handles 0..1000.

Signed-off-by: Karl Palsson <karlp@etactica.com>