### PR TITLE
Remove weird alternate function typestates

### DIFF
--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -33,8 +33,14 @@ const APP: () = {
         rprintln!("  - CAN init");
 
         let mut can = {
-            let rx = gpioa.pa11.into_af9(&mut gpioa.moder, &mut gpioa.afrh);
-            let tx = gpioa.pa12.into_af9(&mut gpioa.moder, &mut gpioa.afrh);
+            let rx =
+                gpioa
+                    .pa11
+                    .into_af9_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+            let tx =
+                gpioa
+                    .pa12
+                    .into_af9_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
 
             let can = Can::new(&mut rcc.apb1r1, dp.CAN1, (tx, rx));
 

--- a/examples/i2c_write.rs
+++ b/examples/i2c_write.rs
@@ -39,17 +39,17 @@ fn main() -> ! {
 
     let mut gpioa = dp.GPIOA.split(&mut rcc.ahb2);
 
-    let mut scl = gpioa
-        .pa9
-        .into_open_drain_output(&mut gpioa.moder, &mut gpioa.otyper);
+    let mut scl =
+        gpioa
+            .pa9
+            .into_af4_opendrain(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
     scl.internal_pull_up(&mut gpioa.pupdr, true);
-    let scl = scl.into_af4(&mut gpioa.moder, &mut gpioa.afrh);
 
-    let mut sda = gpioa
-        .pa10
-        .into_open_drain_output(&mut gpioa.moder, &mut gpioa.otyper);
+    let mut sda =
+        gpioa
+            .pa10
+            .into_af4_opendrain(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
     sda.internal_pull_up(&mut gpioa.pupdr, true);
-    let sda = sda.into_af4(&mut gpioa.moder, &mut gpioa.afrh);
 
     let mut i2c = I2c::i2c1(
         dp.I2C1,

--- a/examples/otg_fs_serial.rs
+++ b/examples/otg_fs_serial.rs
@@ -145,11 +145,11 @@ unsafe fn main() -> ! {
         hclk: clocks.hclk(),
         pin_dm: gpioa
             .pa11
-            .into_af10(&mut gpioa.moder, &mut gpioa.afrh)
+            .into_af10_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh)
             .set_speed(Speed::VeryHigh),
         pin_dp: gpioa
             .pa12
-            .into_af10(&mut gpioa.moder, &mut gpioa.afrh)
+            .into_af10_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh)
             .set_speed(Speed::VeryHigh),
     };
 

--- a/examples/pll_config.rs
+++ b/examples/pll_config.rs
@@ -44,11 +44,15 @@ fn main() -> ! {
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations
-    let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    let tx = gpioa
+        .pa9
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    // let tx = gpiob.pb6.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
-    let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    let rx = gpioa
+        .pa10
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    // let rx = gpiob.pb7.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart1(

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -27,20 +27,16 @@ fn main() -> ! {
     // TIM2
     let c1 = gpioa
         .pa0
-        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
-        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+        .into_af1_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
     let c2 = gpioa
         .pa1
-        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
-        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+        .into_af1_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
     let c3 = gpioa
         .pa2
-        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
-        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+        .into_af1_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
     let c4 = gpioa
         .pa3
-        .into_push_pull_output(&mut gpioa.moder, &mut gpioa.otyper)
-        .into_af1(&mut gpioa.moder, &mut gpioa.afrl);
+        .into_af1_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
     let mut pwm = p
         .TIM2

--- a/examples/qspi.rs
+++ b/examples/qspi.rs
@@ -51,12 +51,30 @@ fn main() -> ! {
     let mut id_arr: [u8; 3] = [0; 3];
 
     let qspi = {
-        let clk = gpioe.pe10.into_af10(&mut gpioe.moder, &mut gpioe.afrh);
-        let ncs = gpioe.pe11.into_af10(&mut gpioe.moder, &mut gpioe.afrh);
-        let io_0 = gpioe.pe12.into_af10(&mut gpioe.moder, &mut gpioe.afrh);
-        let io_1 = gpioe.pe13.into_af10(&mut gpioe.moder, &mut gpioe.afrh);
-        let io_2 = gpioe.pe14.into_af10(&mut gpioe.moder, &mut gpioe.afrh);
-        let io_3 = gpioe.pe15.into_af10(&mut gpioe.moder, &mut gpioe.afrh);
+        let clk =
+            gpioe
+                .pe10
+                .into_af10_pushpull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+        let ncs =
+            gpioe
+                .pe11
+                .into_af10_pushpull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+        let io_0 =
+            gpioe
+                .pe12
+                .into_af10_pushpull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+        let io_1 =
+            gpioe
+                .pe13
+                .into_af10_pushpull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+        let io_2 =
+            gpioe
+                .pe14
+                .into_af10_pushpull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+        let io_3 =
+            gpioe
+                .pe15
+                .into_af10_pushpull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
         Qspi::new(
             p.QUADSPI,
             (clk, ncs, io_0, io_1, io_2, io_3),

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -46,8 +46,12 @@ fn main() -> ! {
 
     // setup usart
     let mut gpioa = device.GPIOA.split(&mut rcc.ahb2);
-    let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
+    let tx = gpioa
+        .pa9
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    let rx = gpioa
+        .pa10
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
 
     let baud_rate = 9_600; // 115_200;
     let serial = Serial::usart1(

--- a/examples/rtic_frame_serial_dma.rs
+++ b/examples/rtic_frame_serial_dma.rs
@@ -63,8 +63,12 @@ const APP: () = {
             .freeze(&mut flash.acr, &mut pwr);
 
         // USART2 pins
-        let tx2 = gpioa.pa2.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-        let rx2 = gpioa.pa3.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
+        let tx2 = gpioa
+            .pa2
+            .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+        let rx2 = gpioa
+            .pa3
+            .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
         // We will listen for the character `a`, this can be changed to any character such as `\0`
         // if using COBS encoding, or `\n` if using string encoding.

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -45,13 +45,17 @@ fn main() -> ! {
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations
-    // let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    let tx = gpioa.pa2.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-    // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    // let tx = gpioa.pa9.into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    let tx = gpioa
+        .pa2
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    // let tx = gpiob.pb6.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
-    // let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    let rx = gpioa.pa3.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-    // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    // let rx = gpioa.pa10.into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    let rx = gpioa
+        .pa3
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    // let rx = gpiob.pb7.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart2(

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -43,11 +43,15 @@ fn main() -> ! {
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations
-    let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    let tx = gpioa
+        .pa9
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    // let tx = gpiob.pb6.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
-    let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    let rx = gpioa
+        .pa10
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    // let rx = gpiob.pb7.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart1(
@@ -136,7 +140,7 @@ fn send(tx: &mut impl embedded_hal::serial::Write<u8>, data: &[u8]) {
     }
 
     // waste some time so that the data will be received completely
-    for i in 0..10000 {
+    for _ in 0..10000 {
         cortex_m::asm::nop();
     }
 }

--- a/examples/serial_dma_us2.rs
+++ b/examples/serial_dma_us2.rs
@@ -41,12 +41,16 @@ fn main() -> ! {
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
     // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
 
-    let tx = gpioa.pa2.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-    // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    let tx = gpioa
+        .pa2
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    // let tx = gpiob.pb6.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
-    // let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    let rx = gpioa.pa3.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-    // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
+    // let rx = gpioa.pa10.into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
+    let rx = gpioa
+        .pa3
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    // let rx = gpiob.pb7.into_af7_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart2(

--- a/examples/serial_echo_rtic.rs
+++ b/examples/serial_echo_rtic.rs
@@ -39,8 +39,14 @@ const APP: () = {
 
         let mut gpioa = p.GPIOA.split(&mut rcc.ahb2);
 
-        let tx_pin = gpioa.pa2.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-        let rx_pin = gpioa.pa3.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
+        let tx_pin =
+            gpioa
+                .pa2
+                .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+        let rx_pin =
+            gpioa
+                .pa3
+                .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
         let mut serial = Serial::usart2(
             p.USART2,

--- a/examples/serial_half_duplex.rs
+++ b/examples/serial_half_duplex.rs
@@ -50,9 +50,8 @@ fn main() -> ! {
     // let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh).set_open_drain();
     let tx = gpioa
         .pa2
-        .into_af7(&mut gpioa.moder, &mut gpioa.afrl)
-        .set_open_drain();
-    // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl).set_open_drain();
+        .into_af7_opendrain(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    // let tx = gpiob.pb6.into_af7_opendrain(&mut gpiob.moder, &mut gpioa.otyper, &mut gpiob.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart2(

--- a/examples/serial_hw_flow.rs
+++ b/examples/serial_hw_flow.rs
@@ -46,15 +46,23 @@ fn main() -> ! {
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations
     // let tx = gpioa.pa9.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    let tx = gpioa.pa2.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
+    let tx = gpioa
+        .pa2
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
     // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
 
     // let rx = gpioa.pa10.into_af7(&mut gpioa.moder, &mut gpioa.afrh);
-    let rx = gpioa.pa3.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
+    let rx = gpioa
+        .pa3
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
     // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
 
-    let rts = gpioa.pa1.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
-    let cts = gpioa.pa0.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
+    let rts = gpioa
+        .pa1
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let cts = gpioa
+        .pa0
+        .into_af7_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart2(

--- a/examples/serial_vcom.rs
+++ b/examples/serial_vcom.rs
@@ -39,11 +39,15 @@ fn main() -> ! {
 
     //let tx = gpioa.pa2.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
     // let tx = gpiob.pb6.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
-    let tx = gpiod.pd5.into_af7(&mut gpiod.moder, &mut gpiod.afrl);
+    let tx = gpiod
+        .pd5
+        .into_af7_pushpull(&mut gpiod.moder, &mut gpiod.otyper, &mut gpiod.afrl);
 
     // let rx = gpioa.pa3.into_af7(&mut gpioa.moder, &mut gpioa.afrl);
     // let rx = gpiob.pb7.into_af7(&mut gpiob.moder, &mut gpiob.afrl);
-    let rx = gpiod.pd6.into_af7(&mut gpiod.moder, &mut gpiod.afrl);
+    let rx = gpiod
+        .pd6
+        .into_af7_pushpull(&mut gpiod.moder, &mut gpiod.otyper, &mut gpiod.afrl);
 
     // TRY using a different USART peripheral here
     let serial = Serial::usart2(

--- a/examples/spi_dma_rxtx.rs
+++ b/examples/spi_dma_rxtx.rs
@@ -46,15 +46,15 @@ const APP: () = {
         //
         let sck = gpiob
             .pb3
-            .into_af5(&mut gpiob.moder, &mut gpiob.afrl)
+            .into_af5_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl)
             .set_speed(Speed::High);
         let miso = gpiob
             .pb4
-            .into_af5(&mut gpiob.moder, &mut gpiob.afrl)
+            .into_af5_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl)
             .set_speed(Speed::High);
         let mosi = gpiob
             .pb5
-            .into_af5(&mut gpiob.moder, &mut gpiob.afrl)
+            .into_af5_pushpull(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl)
             .set_speed(Speed::High);
         let mut dummy_cs = gpiob.pb6.into_push_pull_output_with_state(
             &mut gpiob.moder,

--- a/examples/spi_slave.rs
+++ b/examples/spi_slave.rs
@@ -45,9 +45,15 @@ fn main() -> ! {
     // The `L3gd20` abstraction exposed by the `f3` crate requires a specific pin configuration to
     // be used and won't accept any configuration other than the one used here. Trying to use a
     // different pin configuration will result in a compiler error.
-    let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
+    let sck = gpioa
+        .pa5
+        .into_af5_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let miso = gpioa
+        .pa6
+        .into_af5_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let mosi = gpioa
+        .pa7
+        .into_af5_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
     // clock speed is determined by the master
     let mut spi = Spi::spi1_slave(p.SPI1, (sck, miso, mosi), MODE, &mut rcc.apb2);

--- a/examples/spi_write.rs
+++ b/examples/spi_write.rs
@@ -54,9 +54,15 @@ fn main() -> ! {
     // The `L3gd20` abstraction exposed by the `f3` crate requires a specific pin configuration to
     // be used and won't accept any configuration other than the one used here. Trying to use a
     // different pin configuration will result in a compiler error.
-    let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
+    let sck = gpioa
+        .pa5
+        .into_af5_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let miso = gpioa
+        .pa6
+        .into_af5_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
+    let mosi = gpioa
+        .pa7
+        .into_af5_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrl);
 
     // nss.set_high();
     dc.set_low().ok();

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -63,8 +63,12 @@ fn main() -> ! {
 
     let usb = Peripheral {
         usb: dp.USB,
-        pin_dm: gpioa.pa11.into_af10(&mut gpioa.moder, &mut gpioa.afrh),
-        pin_dp: gpioa.pa12.into_af10(&mut gpioa.moder, &mut gpioa.afrh),
+        pin_dm: gpioa
+            .pa11
+            .into_af10_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
+        pin_dp: gpioa
+            .pa12
+            .into_af10_pushpull(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh),
     };
     let usb_bus = UsbBus::new(usb);
 

--- a/memory.x
+++ b/memory.x
@@ -2,8 +2,8 @@ MEMORY
 {
   /* NOTE K = KiBi = 1024 bytes */
   /* TODO Adjust these memory regions to match your device memory layout */
-  FLASH : ORIGIN = 0x8000000, LENGTH = 256K 
-  RAM : ORIGIN = 0x20000000, LENGTH = 64K
+  FLASH : ORIGIN = 0x8000000, LENGTH = 128K
+  RAM : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* This is where the call stack will be allocated. */

--- a/src/can.rs
+++ b/src/can.rs
@@ -20,8 +20,8 @@ pub trait Pins: sealed::Sealed {
 macro_rules! pins {
     ($($PER:ident => ($tx:ident<$txaf:ident>, $rx:ident<$rxaf:ident>),)+) => {
         $(
-            impl crate::can::sealed::Sealed for ($tx<crate::gpio::Alternate<$txaf, Input<Floating>>>, $rx<crate::gpio::Alternate<$rxaf, Input<Floating>>>) {}
-            impl crate::can::Pins for ($tx<crate::gpio::Alternate<$txaf, Input<Floating>>>, $rx<crate::gpio::Alternate<$rxaf, Input<Floating>>>) {
+            impl crate::can::sealed::Sealed for ($tx<crate::gpio::Alternate<$txaf, PushPull>>, $rx<crate::gpio::Alternate<$rxaf, PushPull>>) {}
+            impl crate::can::Pins for ($tx<crate::gpio::Alternate<$txaf, PushPull>>, $rx<crate::gpio::Alternate<$rxaf, PushPull>>) {
                 type Instance = $PER;
             }
         )+
@@ -33,7 +33,7 @@ mod common_pins {
         gpioa::{PA11, PA12},
         gpiob::{PB8, PB9},
         gpiod::{PD0, PD1},
-        Floating, Input, AF9,
+        PushPull, AF9,
     };
     use crate::pac::CAN1;
 
@@ -49,7 +49,7 @@ mod common_pins {
 mod pb13_pb12_af10 {
     use crate::gpio::{
         gpiob::{PB12, PB13},
-        Floating, Input, AF10,
+        PushPull, AF10,
     };
     use crate::pac::CAN1;
     pins! { CAN1 => (PB13<AF10>, PB12<AF10>), }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -42,12 +42,12 @@ pub trait SdaPin<I2C>: private::Sealed {}
 macro_rules! pins {
     ($spi:ident, $af:ident, SCL: [$($scl:ident),*], SDA: [$($sda:ident),*]) => {
         $(
-            impl super::private::Sealed for $scl<Alternate<$af, Output<OpenDrain>>> {}
-            impl super::SclPin<$spi> for $scl<Alternate<$af, Output<OpenDrain>>> {}
+            impl super::private::Sealed for $scl<Alternate<$af, OpenDrain>> {}
+            impl super::SclPin<$spi> for $scl<Alternate<$af, OpenDrain>> {}
         )*
         $(
-            impl super::private::Sealed for $sda<Alternate<$af, Output<OpenDrain>>> {}
-            impl super::SdaPin<$spi> for $sda<Alternate<$af, Output<OpenDrain>>> {}
+            impl super::private::Sealed for $sda<Alternate<$af, OpenDrain>> {}
+            impl super::SdaPin<$spi> for $sda<Alternate<$af, OpenDrain>> {}
         )*
     }
 }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -8,7 +8,7 @@ use crate::stm32::{TIM1, TIM15, TIM2};
 
 use crate::gpio::gpioa::{PA0, PA1, PA10, PA11, PA15, PA2, PA3, PA8, PA9};
 use crate::gpio::gpiob::{PB10, PB11, PB14, PB3};
-use crate::gpio::{Alternate, AlternateOD, Floating, Input, Output, PushPull, AF1, AF14};
+use crate::gpio::{Alternate, AF1, AF14};
 use crate::rcc::{Clocks, APB1R1, APB2};
 use crate::time::Hertz;
 
@@ -26,14 +26,7 @@ macro_rules! pins_to_channels_mapping {
     ( $( $TIMX:ident: ( $($PINX:ident),+ ), ( $($ENCHX:ident),+ ), ( $($AF:ident),+ ); )+ ) => {
         $(
             #[allow(unused_parens)]
-            impl Pins<$TIMX> for ($($PINX<Alternate<$AF, Output<PushPull>>>),+)
-            {
-                $(const $ENCHX: bool = true;)+
-                type Channels = ($(Pwm<$TIMX, $ENCHX>),+);
-            }
-
-            #[allow(unused_parens)]
-            impl Pins<$TIMX> for ($($PINX<AlternateOD<$AF, Input<Floating>>>),+)
+            impl<OTYPE> Pins<$TIMX> for ($($PINX<Alternate<$AF, OTYPE>>),+)
             {
                 $(const $ENCHX: bool = true;)+
                 type Channels = ($(Pwm<$TIMX, $ENCHX>),+);

--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -32,7 +32,7 @@ use crate::gpio::{
     gpiof::{PF6, PF7, PF8, PF9},
 };
 
-use crate::gpio::{Alternate, Floating, Input, Speed, AF10};
+use crate::gpio::{Alternate, PushPull, Speed, AF10};
 use crate::rcc::AHB3;
 use crate::stm32::QUADSPI;
 use core::ptr;
@@ -72,48 +72,48 @@ macro_rules! pins {
         IO0: [$($io0:ident),*], IO1: [$($io1:ident),*], IO2: [$($io2:ident),*],
         IO3: [$($io3:ident),*]) => {
         $(
-            impl private::Sealed for $clk<Alternate<$af, Input<Floating>>> {}
-            impl ClkPin<$qspi> for $clk<Alternate<$af, Input<Floating>>> {
+            impl private::Sealed for $clk<Alternate<$af, PushPull>> {}
+            impl ClkPin<$qspi> for $clk<Alternate<$af, PushPull>> {
                 fn set_speed(self, speed: Speed) -> Self{
                     self.set_speed(speed)
                 }
             }
         )*
         $(
-            impl private::Sealed for $ncs<Alternate<$af, Input<Floating>>> {}
-            impl NCSPin<$qspi> for $ncs<Alternate<$af, Input<Floating>>> {
+            impl private::Sealed for $ncs<Alternate<$af, PushPull>> {}
+            impl NCSPin<$qspi> for $ncs<Alternate<$af, PushPull>> {
                 fn set_speed(self, speed: Speed) -> Self{
                     self.set_speed(speed)
                 }
             }
         )*
         $(
-            impl private::Sealed for $io0<Alternate<$af, Input<Floating>>> {}
-            impl IO0Pin<$qspi> for $io0<Alternate<$af, Input<Floating>>> {
+            impl private::Sealed for $io0<Alternate<$af, PushPull>> {}
+            impl IO0Pin<$qspi> for $io0<Alternate<$af, PushPull>> {
                 fn set_speed(self, speed: Speed) -> Self{
                     self.set_speed(speed)
                 }
             }
         )*
         $(
-            impl private::Sealed for $io1<Alternate<$af, Input<Floating>>> {}
-            impl IO1Pin<$qspi> for $io1<Alternate<$af, Input<Floating>>> {
+            impl private::Sealed for $io1<Alternate<$af, PushPull>> {}
+            impl IO1Pin<$qspi> for $io1<Alternate<$af, PushPull>> {
                 fn set_speed(self, speed: Speed) -> Self{
                     self.set_speed(speed)
                 }
             }
         )*
         $(
-            impl private::Sealed for $io2<Alternate<$af, Input<Floating>>> {}
-            impl IO2Pin<$qspi> for $io2<Alternate<$af, Input<Floating>>> {
+            impl private::Sealed for $io2<Alternate<$af, PushPull>> {}
+            impl IO2Pin<$qspi> for $io2<Alternate<$af, PushPull>> {
                 fn set_speed(self, speed: Speed) -> Self{
                     self.set_speed(speed)
                 }
             }
         )*
         $(
-            impl private::Sealed for $io3<Alternate<$af, Input<Floating>>> {}
-            impl IO3Pin<$qspi> for $io3<Alternate<$af, Input<Floating>>> {
+            impl private::Sealed for $io3<Alternate<$af, PushPull>> {}
+            impl IO3Pin<$qspi> for $io3<Alternate<$af, PushPull>> {
                 fn set_speed(self, speed: Speed) -> Self{
                     self.set_speed(speed)
                 }
@@ -742,15 +742,15 @@ pins!(
 );
 
 #[cfg(feature = "stm32l4x2")]
-impl IO0Pin<QUADSPI> for PB1<Alternate<AF10, Input<Floating>>> {
+impl IO0Pin<QUADSPI> for PB1<Alternate<AF10, PushPull>> {
     fn set_speed(self, speed: Speed) -> Self {
         self.set_speed(speed)
     }
 }
 #[cfg(feature = "stm32l4x2")]
-impl private::Sealed for PB2<Alternate<AF10, Input<Floating>>> {}
+impl private::Sealed for PB2<Alternate<AF10, PushPull>> {}
 #[cfg(feature = "stm32l4x2")]
-impl IO1Pin<QUADSPI> for PB2<Alternate<AF10, Input<Floating>>> {
+impl IO1Pin<QUADSPI> for PB2<Alternate<AF10, PushPull>> {
     fn set_speed(self, speed: Speed) -> Self {
         self.set_speed(speed)
     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -16,7 +16,7 @@ use crate::dma::{
     dma1, CircBuffer, DMAFrame, FrameReader, FrameSender, Receive, RxDma, TransferPayload,
     Transmit, TxDma,
 };
-use crate::gpio::{self, Alternate, AlternateOD, Floating, Input};
+use crate::gpio::{self, Alternate, OpenDrain, PushPull};
 use crate::pac;
 use crate::rcc::{Clocks, APB1R1, APB2};
 use crate::time::{Bps, U32Ext};
@@ -912,37 +912,37 @@ macro_rules! impl_pin_traits {
             $(
                 $(
                     impl private::SealedTx for
-                        gpio::$tx<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$tx<Alternate<gpio::$af, PushPull>> {}
                     impl TxPin<pac::$instance> for
-                        gpio::$tx<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$tx<Alternate<gpio::$af, PushPull>> {}
                 )*
 
                 $(
                     impl private::SealedTxHalfDuplex for
-                        gpio::$tx<AlternateOD<gpio::$af, Input<Floating>>> {}
+                        gpio::$tx<Alternate<gpio::$af, OpenDrain>> {}
                     impl TxHalfDuplexPin<pac::$instance> for
-                        gpio::$tx<AlternateOD<gpio::$af, Input<Floating>>> {}
+                        gpio::$tx<Alternate<gpio::$af, OpenDrain>> {}
                 )*
 
                 $(
                     impl private::SealedRx for
-                        gpio::$rx<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$rx<Alternate<gpio::$af, PushPull>> {}
                     impl RxPin<pac::$instance> for
-                        gpio::$rx<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$rx<Alternate<gpio::$af, PushPull>> {}
                 )*
 
                 $(
                     impl private::SealedRtsDe for
-                        gpio::$rts_de<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$rts_de<Alternate<gpio::$af, PushPull>> {}
                     impl RtsDePin<pac::$instance> for
-                        gpio::$rts_de<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$rts_de<Alternate<gpio::$af, PushPull>> {}
                 )*
 
                 $(
                     impl private::SealedCts for
-                        gpio::$cts<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$cts<Alternate<gpio::$af, PushPull>> {}
                     impl CtsPin<pac::$instance> for
-                        gpio::$cts<Alternate<gpio::$af, Input<Floating>>> {}
+                        gpio::$cts<Alternate<gpio::$af, PushPull>> {}
                 )*
             )*
         )*

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -10,7 +10,7 @@ use core::sync::atomic;
 use core::sync::atomic::Ordering;
 
 use crate::dma::{self, dma1, dma2, TransferPayload};
-use crate::gpio::{Alternate, Floating, Input, AF5};
+use crate::gpio::{Alternate, PushPull, AF5};
 use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
 use crate::rcc::{Clocks, APB1R1, APB2};
 use crate::time::Hertz;
@@ -44,16 +44,16 @@ pub trait MosiPin<SPI>: private::Sealed {}
 macro_rules! pins {
     ($spi:ident, $af:ident, SCK: [$($sck:ident),*], MISO: [$($miso:ident),*], MOSI: [$($mosi:ident),*]) => {
         $(
-            impl private::Sealed for $sck<Alternate<$af, Input<Floating>>> {}
-            impl SckPin<$spi> for $sck<Alternate<$af, Input<Floating>>> {}
+            impl private::Sealed for $sck<Alternate<$af, PushPull>> {}
+            impl SckPin<$spi> for $sck<Alternate<$af, PushPull>> {}
         )*
         $(
-            impl private::Sealed for $miso<Alternate<$af, Input<Floating>>> {}
-            impl MisoPin<$spi> for $miso<Alternate<$af, Input<Floating>>> {}
+            impl private::Sealed for $miso<Alternate<$af, PushPull>> {}
+            impl MisoPin<$spi> for $miso<Alternate<$af, PushPull>> {}
         )*
         $(
-            impl private::Sealed for $mosi<Alternate<$af, Input<Floating>>> {}
-            impl MosiPin<$spi> for $mosi<Alternate<$af, Input<Floating>>> {}
+            impl private::Sealed for $mosi<Alternate<$af, PushPull>> {}
+            impl MosiPin<$spi> for $mosi<Alternate<$af, PushPull>> {}
         )*
     }
 }

--- a/src/tsc.rs
+++ b/src/tsc.rs
@@ -8,7 +8,7 @@
 //! electrode fitting a human finger tip size across a few millimeters dielectric panel.
 
 use crate::gpio::gpiob::{PB4, PB5, PB6, PB7};
-use crate::gpio::{Alternate, OpenDrain, Output, PushPull, AF9};
+use crate::gpio::{Alternate, OpenDrain, PushPull, AF9};
 use crate::rcc::AHB1;
 use crate::stm32::TSC;
 
@@ -32,19 +32,19 @@ pub trait SamplePin<TSC> {
     const GROUP: u32;
     const OFFSET: u32;
 }
-impl SamplePin<TSC> for PB4<Alternate<AF9, Output<OpenDrain>>> {
+impl SamplePin<TSC> for PB4<Alternate<AF9, OpenDrain>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 0;
 }
-impl SamplePin<TSC> for PB5<Alternate<AF9, Output<OpenDrain>>> {
+impl SamplePin<TSC> for PB5<Alternate<AF9, OpenDrain>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 1;
 }
-impl SamplePin<TSC> for PB6<Alternate<AF9, Output<OpenDrain>>> {
+impl SamplePin<TSC> for PB6<Alternate<AF9, OpenDrain>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 2;
 }
-impl SamplePin<TSC> for PB7<Alternate<AF9, Output<OpenDrain>>> {
+impl SamplePin<TSC> for PB7<Alternate<AF9, OpenDrain>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 3;
 }
@@ -53,19 +53,19 @@ pub trait ChannelPin<TSC> {
     const GROUP: u32;
     const OFFSET: u32;
 }
-impl ChannelPin<TSC> for PB4<Alternate<AF9, Output<PushPull>>> {
+impl ChannelPin<TSC> for PB4<Alternate<AF9, PushPull>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 0;
 }
-impl ChannelPin<TSC> for PB5<Alternate<AF9, Output<PushPull>>> {
+impl ChannelPin<TSC> for PB5<Alternate<AF9, PushPull>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 1;
 }
-impl ChannelPin<TSC> for PB6<Alternate<AF9, Output<PushPull>>> {
+impl ChannelPin<TSC> for PB6<Alternate<AF9, PushPull>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 2;
 }
-impl ChannelPin<TSC> for PB7<Alternate<AF9, Output<PushPull>>> {
+impl ChannelPin<TSC> for PB7<Alternate<AF9, PushPull>> {
     const GROUP: u32 = 2;
     const OFFSET: u32 = 3;
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -9,13 +9,13 @@ use crate::stm32::{RCC, USB};
 use stm32_usbd::UsbPeripheral;
 
 use crate::gpio::gpioa::{PA11, PA12};
-use crate::gpio::{Alternate, Floating, Input, AF10};
+use crate::gpio::{Alternate, PushPull, AF10};
 pub use stm32_usbd::UsbBus;
 
 pub struct Peripheral {
     pub usb: USB,
-    pub pin_dm: PA11<Alternate<AF10, Input<Floating>>>,
-    pub pin_dp: PA12<Alternate<AF10, Input<Floating>>>,
+    pub pin_dm: PA11<Alternate<AF10, PushPull>>,
+    pub pin_dp: PA12<Alternate<AF10, PushPull>>,
 }
 
 unsafe impl Sync for Peripheral {}
@@ -28,7 +28,7 @@ unsafe impl UsbPeripheral for Peripheral {
     const EP_MEMORY_ACCESS_2X16: bool = true;
 
     fn enable() {
-        let rcc = unsafe { (&*RCC::ptr()) };
+        let rcc = unsafe { &*RCC::ptr() };
 
         cortex_m::interrupt::free(|_| {
             // Enable USB peripheral


### PR DESCRIPTION
The following table summarizes how GPIOs can be configured:

![Screenshot_2021-09-12_13-38-53](https://user-images.githubusercontent.com/7713259/132986093-ea57f969-79f0-43c8-b5f4-c2ce816c3f33.png)

Until now, we could have GPIO typestates like `PAx<Alternate<AFy, Output<OpenDrain>>>` or `PAx<Alternate<AFy, Input<Floating>>>` which do not make any sense because they do not have any representation in the actual hardware configuration. I have replaced those by `PAx<Alternate<AFy, PushPull>>` and `PAx<Alternate<AFy, OpenDrain>>` because that is the only distinction we can make on that level.

I have called the methods `into_af0_pushpull` and `into_af0_opendrain` which is a little bit inconsistent with `into_open_drain_output` and `into_push_pull_output`. Would you like `into_af0_open_drain` or `into_open_drain_af0` more, then I can also change this.

The stm32f1xx-hal crate also has a nice approach to this topic. It does not include the AF-number in the GPIO typestate (see, for example, its [PA0::into_alternate_push_pull](https://docs.rs/stm32f1xx-hal/0.7.0/stm32f1xx_hal/gpio/gpioa/struct.PA0.html#method.into_alternate_push_pull)) but sets this up when the peripheral is initialized (for example [BlockingI2c::i2c1](https://github.com/stm32-rs/stm32f1xx-hal/blob/master/examples/i2c-bme280/src/main.rs#L69)). Currently, I do not know if this has any downsides so I did what I consider the least that should definitely be done.

Finally, I am a little bit confused why the pull-up/pull-down state is included in the `Input` typestates, but not in the `Output` and `Alternate` typestates. At least, this is an inconsistency, too. Do we want to revise this?