### PR TITLE
Fix confusion between pin number and AF number

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -149,7 +149,7 @@ macro_rules! impl_into_af {
                     // push pull output
                     otyper
                         .otyper()
-                        .modify(|r, w| unsafe { w.bits(r.bits() & !(0b1 << $NUM)) });
+                        .modify(|r, w| unsafe { w.bits(r.bits() & !(0b1 << $i)) });
                     afr.afr().modify(|r, w| unsafe {
                         w.bits((r.bits() & !(0b1111 << OFF_AFR)) | ($NUM << OFF_AFR))
                     });
@@ -170,7 +170,7 @@ macro_rules! impl_into_af {
                     // open drain output
                     otyper
                         .otyper()
-                        .modify(|r, w| unsafe { w.bits(r.bits() | (0b1 << $NUM)) });
+                        .modify(|r, w| unsafe { w.bits(r.bits() | (0b1 << $i)) });
                     afr.afr().modify(|r, w| unsafe {
                         w.bits((r.bits() & !(0b1111 << OFF_AFR)) | ($NUM << OFF_AFR))
                     });


### PR DESCRIPTION
Unfortunately, I got lost in the macro depths when working on the gpio typestates and a small but significant bug sneaked in. When requesting pin PAx to AFy, this erroneously configured PAy to get the requested output type (push-pull or open-drain). This is fixed now.