### PR TITLE
Added RTC domain backup registers support.

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -466,6 +466,22 @@ impl Rtc {
 
         result
     }
+
+    /// Read content of the backup register.
+    ///
+    /// The registers retain their values during wakes from standby mode or system resets. They also
+    /// retain their value when Vdd is switched off as long as V_BAT is powered.
+    pub fn read_backup_register(&self, register: usize) -> u32 {
+        self.rtc.bkpr[register].read().bits()
+    }
+
+    /// Set content of the backup register.
+    ///
+    /// The registers retain their values during wakes from standby mode or system resets. They also
+    /// retain their value when Vdd is switched off as long as V_BAT is powered.
+    pub fn write_backup_register(&self, register: usize, value: u32) {
+        unsafe { self.rtc.bkpr[register].write(|w| w.bits(value)) }
+    }
 }
 
 /// The RTC wakeup timer

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -471,8 +471,12 @@ impl Rtc {
     ///
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
-    pub fn read_backup_register(&self, register: usize) -> u32 {
-        self.rtc.bkpr[register].read().bits()
+    pub fn read_backup_register(&self, register: usize) -> Option<u32> {
+        if register < 32 {
+            Some(self.rtc.bkpr[register].read().bits())
+        } else {
+            None
+        }
     }
 
     /// Set content of the backup register.
@@ -480,7 +484,9 @@ impl Rtc {
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
     pub fn write_backup_register(&self, register: usize, value: u32) {
-        unsafe { self.rtc.bkpr[register].write(|w| w.bits(value)) }
+        if register < 32 {
+            unsafe { self.rtc.bkpr[register].write(|w| w.bits(value)) }
+        }
     }
 }
 


### PR DESCRIPTION
As BKP is a part of RTC hardware, putting BKP access functions to the RTC module seem to be a reasonable idea