### PR TITLE
add r9/s9 to the job matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           use-cross: true
           command: build
           args: --verbose --release --target thumbv7em-none-eabihf --features rt,unproven,${{ matrix.mcu }}
+      # note that examples were not built
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,33 @@ jobs:
         with:
           command: test
           args: --lib --target x86_64-unknown-linux-gnu --features rt,unproven,${{ matrix.mcu }}
+
+  ci-r9:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        mcu:
+          - stm32l4r9
+          - stm32l4s9
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: thumbv7em-none-eabihf
+          override: true
+      - name: build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --verbose --release --target thumbv7em-none-eabihf --features rt,unproven,${{ matrix.mcu }}
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --lib --target x86_64-unknown-linux-gnu --features rt,unproven,${{ matrix.mcu }}


### PR DESCRIPTION
Even with incomplete support, should still ensure that things compile
enable specific examples as support is filled out