### PR TITLE
Proposal: feature detection macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 **/*.rs.bk
 Cargo.lock
 
@@ -7,4 +7,4 @@ Cargo.lock
 /logs
 
 # Visual Studio Code
-/.vscode
+.vscode/

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -1,0 +1,7 @@
+//! The feature detection module provides a level of abstraction and (hopefully) clarity to the crate features defined in cargo.toml
+//! Primarily this will take the form of macros wrapping #[cfg(...)], but some const declarations may also prove useful
+//!
+//! NOTE: macros are disallowed inside #[cfg(...)] so the macro calls themselves will have to enclose this
+
+mod peripherals;
+pub(crate) use peripherals::*;

--- a/src/feature/peripherals.rs
+++ b/src/feature/peripherals.rs
@@ -1,0 +1,582 @@
+macro_rules! if_adc2 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_adc2;
+
+macro_rules! if_adc3 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_adc3;
+
+macro_rules! if_dac1 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_dac1;
+
+macro_rules! if_comp1 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_comp1;
+
+macro_rules! if_comp2 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_comp2;
+
+macro_rules! if_dfsdm1 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_dfsdm1;
+
+macro_rules! if_lcd {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l433",
+            feature = "stm32l443",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l433",
+            feature = "stm32l443",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_lcd;
+
+macro_rules! if_aes {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l422",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l422",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_aes;
+
+macro_rules! if_tim3 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_tim3;
+
+macro_rules! if_tim7 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_tim7;
+
+macro_rules! if_i2c3 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_i2c3;
+
+macro_rules! if_i2c4 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_i2c4;
+
+macro_rules! if_usart3 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_usart3;
+
+macro_rules! if_uart4 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_uart4;
+
+macro_rules! if_spi2 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_spi2;
+
+macro_rules! if_spi3 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_spi3;
+
+macro_rules! if_sai {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_sai;
+
+macro_rules! if_swpmi1 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_swpmi1;
+
+macro_rules! if_sdmmc {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_sdmmc;
+
+macro_rules! if_usb_fs {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_usb_fs;
+
+macro_rules! if_can1 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        $ex
+    };
+}
+pub(crate) use if_can1;
+

--- a/src/feature/peripherals.rs
+++ b/src/feature/peripherals.rs
@@ -18,9 +18,55 @@ macro_rules! if_adc2 {
             feature = "stm32l4r9",
             feature = "stm32l4s9",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l412",
             feature = "stm32l422",
@@ -62,9 +108,51 @@ macro_rules! if_adc3 {
             feature = "stm32l4r9",
             feature = "stm32l4s9",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l471",
+            feature = "stm32l475",
+            feature = "stm32l476",
+            feature = "stm32l486",
+            feature = "stm32l496",
+            feature = "stm32l4a6",
+            feature = "stm32l4p5",
+            feature = "stm32l4q5",
+            feature = "stm32l4r5",
+            feature = "stm32l4s5",
+            feature = "stm32l4r7",
+            feature = "stm32l4s7",
+            feature = "stm32l4r9",
+            feature = "stm32l4s9",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l471",
             feature = "stm32l475",
@@ -98,9 +186,39 @@ macro_rules! if_dac1 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -128,9 +246,39 @@ macro_rules! if_comp1 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -158,9 +306,39 @@ macro_rules! if_comp2 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -178,19 +356,23 @@ pub(crate) use if_comp2;
 
 macro_rules! if_dfsdm1 {
     (present: $ex:expr) => {
-        #[cfg(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        ))]
-        $ex
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
-        #[cfg(not(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        )))]
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        $ex
+    };
+    (absent: $ex:item) => {
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
         $ex
     };
 }
@@ -198,17 +380,23 @@ pub(crate) use if_dfsdm1;
 
 macro_rules! if_lcd {
     (present: $ex:expr) => {
-        #[cfg(any(
-            feature = "stm32l433",
-            feature = "stm32l443",
-        ))]
-        $ex
+        #[cfg(any(feature = "stm32l433", feature = "stm32l443",))]
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
-        #[cfg(not(any(
-            feature = "stm32l433",
-            feature = "stm32l443",
-        )))]
+        #[cfg(not(any(feature = "stm32l433", feature = "stm32l443",)))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(feature = "stm32l433", feature = "stm32l443",))]
+        $ex
+    };
+    (absent: $ex:item) => {
+        #[cfg(not(any(feature = "stm32l433", feature = "stm32l443",)))]
         $ex
     };
 }
@@ -222,9 +410,31 @@ macro_rules! if_aes {
             feature = "stm32l443",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l422",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l422",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l422",
             feature = "stm32l442",
@@ -238,19 +448,23 @@ pub(crate) use if_aes;
 
 macro_rules! if_tim3 {
     (present: $ex:expr) => {
-        #[cfg(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        ))]
-        $ex
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
-        #[cfg(not(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        )))]
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        $ex
+    };
+    (absent: $ex:item) => {
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
         $ex
     };
 }
@@ -265,9 +479,33 @@ macro_rules! if_tim7 {
             feature = "stm32l442",
             feature = "stm32l443",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -292,9 +530,39 @@ macro_rules! if_i2c3 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l412",
             feature = "stm32l422",
@@ -312,19 +580,23 @@ pub(crate) use if_i2c3;
 
 macro_rules! if_i2c4 {
     (present: $ex:expr) => {
-        #[cfg(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        ))]
-        $ex
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
-        #[cfg(not(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        )))]
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        $ex
+    };
+    (absent: $ex:item) => {
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
         $ex
     };
 }
@@ -342,9 +614,39 @@ macro_rules! if_usart3 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l412",
             feature = "stm32l422",
@@ -362,19 +664,23 @@ pub(crate) use if_usart3;
 
 macro_rules! if_uart4 {
     (present: $ex:expr) => {
-        #[cfg(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        ))]
-        $ex
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
-        #[cfg(not(any(
-            feature = "stm32l451",
-            feature = "stm32l452",
-            feature = "stm32l462",
-        )))]
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",))]
+        $ex
+    };
+    (absent: $ex:item) => {
+        #[cfg(not(any(feature = "stm32l451", feature = "stm32l452", feature = "stm32l462",)))]
         $ex
     };
 }
@@ -392,9 +698,39 @@ macro_rules! if_spi2 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l412",
             feature = "stm32l422",
@@ -422,9 +758,39 @@ macro_rules! if_spi3 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -452,9 +818,39 @@ macro_rules! if_sai {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -479,9 +875,33 @@ macro_rules! if_swpmi1 {
             feature = "stm32l442",
             feature = "stm32l443",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -504,9 +924,35 @@ macro_rules! if_sdmmc {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l433",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l433",
@@ -532,9 +978,39 @@ macro_rules! if_usb_fs {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l412",
+            feature = "stm32l422",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l412",
             feature = "stm32l422",
@@ -562,9 +1038,39 @@ macro_rules! if_can1 {
             feature = "stm32l452",
             feature = "stm32l462",
         ))]
-        $ex
+        {
+            $ex
+        }
     };
     (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        )))]
+        {
+            $ex
+        }
+    };
+    (present: $ex:item) => {
+        #[cfg(any(
+            feature = "stm32l431",
+            feature = "stm32l432",
+            feature = "stm32l433",
+            feature = "stm32l442",
+            feature = "stm32l443",
+            feature = "stm32l451",
+            feature = "stm32l452",
+            feature = "stm32l462",
+        ))]
+        $ex
+    };
+    (absent: $ex:item) => {
         #[cfg(not(any(
             feature = "stm32l431",
             feature = "stm32l432",
@@ -579,4 +1085,3 @@ macro_rules! if_can1 {
     };
 }
 pub(crate) use if_can1;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,3 +204,5 @@ mod sealed {
     pub trait Sealed {}
 }
 pub(crate) use sealed::Sealed;
+
+pub(crate) mod feature;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -25,14 +25,10 @@ use crate::hal::timer::{CountDown, Periodic};
 ))]
 use crate::stm32::TIM3;
 */
-#[cfg(not(any(
-    feature = "stm32l412",
-    feature = "stm32l422",
-    feature = "stm32l451",
-    feature = "stm32l452",
-    feature = "stm32l462",
-)))]
-use crate::stm32::TIM7;
+crate::feature::if_tim7! (present:
+    use crate::stm32::TIM7;
+);
+
 use crate::stm32::{TIM15, TIM16, TIM2, TIM6};
 #[cfg(any(
     // feature = "stm32l471", // missing PAC support
@@ -300,16 +296,11 @@ hal! {
 }
 */
 
-#[cfg(not(any(
-    feature = "stm32l412",
-    feature = "stm32l422",
-    feature = "stm32l451",
-    feature = "stm32l452",
-    feature = "stm32l462",
-)))]
-hal! {
-    TIM7:  (tim7, free_running_tim7, APB1R1, u16),
-}
+crate::feature::if_tim7!(
+    present: hal! {
+        TIM7:  (tim7, free_running_tim7, APB1R1, u16),
+    }
+);
 
 #[cfg(any(
     feature = "stm32l475",

--- a/tools/feature_tables/Cargo.toml
+++ b/tools/feature_tables/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "feature_tables"
+version = "0.0.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tools/feature_tables/src/main.rs
+++ b/tools/feature_tables/src/main.rs
@@ -1,0 +1,171 @@
+//! tool used to generate the feature macros for stm32l4xx-hal
+//! the macros are a whole lot of copy paste, change which MCUs are enabled. This is much easier to handle as a mini-program
+
+use std::{fs, path::Path};
+
+fn main() {
+    let out_dir = "out";
+    fs::create_dir(out_dir).unwrap();
+    let dest_path = Path::new(&out_dir).join("peripherals.rs");
+    write_peripherals(&dest_path);
+}
+
+const L412: &str = "stm32l412";
+const L422: &str = "stm32l422";
+const L431: &str = "stm32l431";
+const L432: &str = "stm32l432";
+const L433: &str = "stm32l433";
+const L442: &str = "stm32l442";
+const L443: &str = "stm32l443";
+const L451: &str = "stm32l451";
+const L452: &str = "stm32l452";
+const L462: &str = "stm32l462";
+const L471: &str = "stm32l471";
+const L475: &str = "stm32l475";
+const L476: &str = "stm32l476";
+const L486: &str = "stm32l486";
+const L496: &str = "stm32l496";
+const L4A6: &str = "stm32l4a6";
+// L4+
+const L4P5: &str = "stm32l4p5";
+const L4Q5: &str = "stm32l4q5";
+const L4R5: &str = "stm32l4r5";
+const L4S5: &str = "stm32l4s5";
+const L4R7: &str = "stm32l4r7";
+const L4S7: &str = "stm32l4s7";
+const L4R9: &str = "stm32l4r9";
+const L4S9: &str = "stm32l4s9";
+
+const HAS_ADC2: [&str; 16] = [
+    L412, L422, L471, L475, L476, L486, L496, L4A6, L4P5, L4Q5, L4R5, L4S5, L4R7, L4S7, L4R9, L4S9,
+];
+
+const HAS_ADC3: [&str; 14] = [
+    L471, L475, L476, L486, L496, L4A6, L4P5, L4Q5, L4R5, L4S5, L4R7, L4S7, L4R9, L4S9,
+];
+
+const HAS_DAC1: [&str; 8] = [L431, L432, L433, L442, L443, L451, L452, L462];
+
+const HAS_COMP1: [&str; 8] = [L431, L432, L433, L442, L443, L451, L452, L462];
+
+const HAS_COMP2: [&str; 8] = [L431, L432, L433, L442, L443, L451, L452, L462];
+
+const HAS_DFSDM1: [&str; 3] = [L451, L452, L462];
+
+const HAS_LCD: [&str; 2] = [L433, L443];
+
+const HAS_AES: [&str; 4] = [L422, L442, L443, L462];
+
+const HAS_TIM3: [&str; 3] = [L451, L452, L462];
+
+const HAS_TIM7: [&str; 5] = [L431, L432, L433, L442, L443];
+
+const HAS_I2C2: [&str; 8] = [L412, L422, L431, L433, L443, L451, L452, L462];
+
+const HAS_I2C4: [&str; 3] = [L451, L452, L462];
+
+const HAS_USART3: [&str; 8] = [L412, L422, L431, L433, L443, L451, L452, L462];
+
+const HAS_UART4: [&str; 3] = [L451, L452, L462];
+
+const HAS_SPI2: [&str; 8] = [L412, L422, L431, L433, L443, L451, L452, L462];
+
+const HAS_SPI3: [&str; 8] = [L431, L432, L433, L442, L443, L451, L452, L462];
+
+const HAS_SAI: [&str; 8] = [L431, L432, L433, L442, L443, L451, L452, L462];
+
+const HAS_SWPMI1: [&str; 5] = [L431, L432, L433, L442, L443];
+
+const HAS_SDMMC: [&str; 6] = [L431, L433, L443, L451, L452, L462];
+
+const HAS_USB_FS: [&str; 8] = [L412, L422, L432, L433, L442, L443, L452, L462];
+
+const HAS_CAN1: [&str; 8] = [L431, L432, L433, L442, L443, L451, L452, L462];
+
+fn write_peripherals(dest_file: &Path) {
+    let mut out = String::new();
+    write_macro(&mut out, "if_adc2", &HAS_ADC2);
+    write_macro(&mut out, "if_adc3", &HAS_ADC3);
+    write_macro(&mut out, "if_dac1", &HAS_DAC1);
+    write_macro(&mut out, "if_comp1", &HAS_COMP1);
+    write_macro(&mut out, "if_comp2", &HAS_COMP2);
+    write_macro(&mut out, "if_dfsdm1", &HAS_DFSDM1);
+    write_macro(&mut out, "if_lcd", &HAS_LCD);
+    write_macro(&mut out, "if_aes", &HAS_AES);
+    write_macro(&mut out, "if_tim3", &HAS_TIM3);
+    write_macro(&mut out, "if_tim7", &HAS_TIM7);
+    write_macro(&mut out, "if_i2c3", &HAS_I2C2);
+    write_macro(&mut out, "if_i2c4", &HAS_I2C4);
+    write_macro(&mut out, "if_usart3", &HAS_USART3);
+    write_macro(&mut out, "if_uart4", &HAS_UART4);
+    write_macro(&mut out, "if_spi2", &HAS_SPI2);
+    write_macro(&mut out, "if_spi3", &HAS_SPI3);
+    write_macro(&mut out, "if_sai", &HAS_SAI);
+    write_macro(&mut out, "if_swpmi1", &HAS_SWPMI1);
+    write_macro(&mut out, "if_sdmmc", &HAS_SDMMC);
+    write_macro(&mut out, "if_usb_fs", &HAS_USB_FS);
+    write_macro(&mut out, "if_can1", &HAS_CAN1);
+
+    fs::write(dest_file, out).unwrap();
+}
+
+fn write_macro(append_to: &mut String, name: &str, features: &[&str]) {
+    let tab_1 = str::repeat(" ", 4);
+    let tab_2 = str::repeat(" ", 8);
+    let tab_3 = str::repeat(" ", 12);
+    let feature_list = features.iter().fold(String::new(), |mut curr, &s| {
+        curr.push_str(&format!("{}feature = {:?},\n", tab_3, s));
+        curr
+    });
+
+    append_to.push_str(&format!("macro_rules! {} {{\n", name));
+    // present
+    append_to.push_str(&format!("{}(present: $ex:expr) => {{\n", tab_1));
+    append_to.push_str(&format!(
+        "{}#[cfg(any(\n{}{}))]\n",
+        tab_2, feature_list, tab_2
+    ));
+    append_to.push_str(&format!("{}$ex\n", tab_2));
+    append_to.push_str(&format!("{}}};\n", tab_1));
+    // absent
+    append_to.push_str(&format!("{}(absent: $ex:expr) => {{\n", tab_1));
+    append_to.push_str(&format!(
+        "{}#[cfg(not(any(\n{}{})))]\n",
+        tab_2, feature_list, tab_2
+    ));
+    append_to.push_str(&format!("{}$ex\n", tab_2));
+    append_to.push_str(&format!("{}}};\n", tab_1));
+    // footer
+    append_to.push_str("}\n");
+    append_to.push_str(&format!("pub(crate) use {};\n\n", name));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_macro() {
+        let target = r#"macro_rules! is_l471 {
+    (present: $ex:expr) => {
+        #[cfg(any(
+            feature = "stm32l471",
+        ))]
+        $ex
+    };
+    (absent: $ex:expr) => {
+        #[cfg(not(any(
+            feature = "stm32l471",
+        )))]
+        $ex
+    };
+}
+pub(crate) use is_l471;
+
+"#; // note the two trailing newlines
+        let mut out = String::new();
+        write_macro(&mut out, "is_l471", &["stm32l471"]);
+        print!("{}", out);
+        assert_eq!(out, target);
+    }
+}


### PR DESCRIPTION
#277 
Looking for feedback on pretty much everything here (right from "should this be a thing").

* Using a seperate utility to generate the macros (see `tools/feature_tables`) which removes the work of dealing with the boilerplate in preipherals.rs. Currently just copying the generated output to the `feature/peripheral.rs` file
* Not 100% certain on which fragment specifiers to use. Currently `expr` (with an added block) and `item`
* using the keywords `present: ` and `absent: ` to do if and if-not. These could easily be two seperate macros (i.e. `if_adc2_present!`).
* Could/Should the generator tool exist as a seperate crate that other HALs can use (with plenty of cleanup)?
* Is this something that should go in a build script?
* Impact on compile times of the added macros?
* should peripherals that are always present (e.g. ADC1) have a feature macro for consistency?

Note: I've only used this on TIM7 declarations so far to get a basic idea of how it looks
TODO: fill out the peripheral tables for L47-L4S devices
TODO: add non-peripheral instance features (e.g. RTC type 2 / RTC type 3, device family (e.g. L4x3, L43_44), ...?), GPIOx, ...)
TODO: replace most(/all?) cfg blocks with macros