### PR TITLE
Fix RTC Wakeup timer stall

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -628,7 +628,7 @@ impl timer::Cancel for WakeupTimer<'_> {
         self.rtc.write(false, |rtc| {
             // Disable the wakeup timer
             rtc.cr.modify(|_, w| w.wute().clear_bit());
-            while rtc_registers::is_wakeup_timer_write_flag_set(&rtc) {}
+            while !rtc_registers::is_wakeup_timer_write_flag_set(rtc) {}
             rtc_registers::clear_wakeup_timer_flag(rtc);
 
             // According to the reference manual, section 26.7.4, the WUTF flag


### PR DESCRIPTION
condition wrongly inverted by [0e66113](https://github.com/stm32-rs/stm32l4xx-hal/commit/0e661138a5f4ebc255550438444ac8c2d7dfd0d1#diff-27f77b66fb3d3624adbb9ac9e90b661819630850787da3b9f47a48a663a5634cR631). This indefinitely stalls the MCU if the wakeup timer is used :/

Procedure is the same for RTC2 and RTC3, the WUTWF is just in different registers