### PR TITLE
#294 rtt logging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,8 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # uncomment ONE of these three option to make `cargo run` start a GDB session
 # which option to pick depends on your system
-runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+runner = "probe-run"
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 # runner = "gdb-multiarch -q -x openocd.gdb"
 # runner = "gdb -q -x openocd.gdb"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,6 +23,9 @@ rustflags = [
   # "-C", "linker=arm-none-eabi-gcc",
   # "-C", "link-arg=-Wl,-Tlink.x",
   # "-C", "link-arg=-nostartfiles",
+
+  # for defmt in examples
+  "-C", "link-arg=-Tdefmt.x",
 ]
 
 [build]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ default-features = false
 features = ["cortex-m-7"]
 
 [profile.dev]
+debug = true
 incremental = false
 codegen-units = 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,8 @@ cortex-m-rt = "0.7"
 usb-device = "0.2.3"
 usbd-serial = "0.1.0"
 heapless = "0.5"
+defmt = "0.3"
+panic-probe = { version = "0.3", features = [ "print-defmt" ] }
 
 [dev-dependencies.cortex-m-rtic]
 version = "0.5.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,28 +108,18 @@ stm32l4r9 = [ "stm32l4/stm32l4r9" ] # PAC has an L4r9 specific variation
 stm32l4s9 = [ "stm32l4/stm32l4r9" ]
 
 [dev-dependencies]
-panic-halt = "0.2.0"
-panic-semihosting = "0.5.0"
-cortex-m-semihosting = "0.3.5"
 cortex-m-rt = "0.7"
 usb-device = "0.2.3"
 usbd-serial = "0.1.0"
-heapless = "0.5"
+heapless = "0.7"
 defmt = "0.3"
+defmt-rtt = "0.3"
 panic-probe = { version = "0.3", features = [ "print-defmt" ] }
 
 [dev-dependencies.cortex-m-rtic]
 version = "0.5.9"
 default-features = false
 features = ["cortex-m-7"]
-
-[dev-dependencies.panic-rtt-target]
-version  = "0.1.1"
-features = ["cortex-m"]
-
-[dev-dependencies.rtt-target]
-version  = "0.2.2"
-features = ["cortex-m"]
 
 [profile.dev]
 incremental = false

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# Running examples
+The easiest way to run examples is with the probe-run cargo extension.
+See the [Installation](https://github.com/knurling-rs/probe-run#installation) section of the probe-run readme for details.
+
+Examples will print messages using RTT for transport. Probe-run will open the debug log once it has completed flashing the firmware. Use probe-run --list-chips and find the correct ID for your MCU
+
+Running the blinky example on a L433 Nucleo
+```sh
+# arguments after the "-- " are to tell probe-run which MCU we are flashing the image to
+cargo run --features=rt,stm32l433 --example=blinky -- --chip STM32L433RCTx
+```

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,16 +1,14 @@
 #![no_main]
 #![no_std]
 
-use panic_rtt_target as _;
-
 use cortex_m_rt::entry;
-use rtt_target::{rprint, rprintln};
+use defmt::println;
+use panic_probe as _;
 use stm32l4xx_hal::{adc::ADC, delay::Delay, pac, prelude::*};
 
 #[entry]
 fn main() -> ! {
-    rtt_target::rtt_init_print!();
-    rprint!("Initializing...");
+    println!("Initializing...");
 
     let cp = pac::CorePeripherals::take().unwrap();
     let dp = pac::Peripherals::take().unwrap();
@@ -33,10 +31,10 @@ fn main() -> ! {
     let mut gpioc = dp.GPIOC.split(&mut rcc.ahb2);
     let mut a1 = gpioc.pc0.into_analog(&mut gpioc.moder, &mut gpioc.pupdr);
 
-    rprintln!(" done.");
+    println!("Initializing done.");
 
     loop {
         let value = adc.read(&mut a1).unwrap();
-        rprintln!("Value: {}", value);
+        println!("Value: {}", value);
     }
 }

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -3,6 +3,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{adc::ADC, delay::Delay, pac, prelude::*};
 

--- a/examples/adc_dma.rs
+++ b/examples/adc_dma.rs
@@ -1,16 +1,15 @@
 #![no_main]
 #![no_std]
 
-use panic_rtt_target as _;
-use rtt_target::{rprintln, rtt_init_print};
+use defmt::println;
+use panic_probe as _;
+use rtic::app;
 use stm32l4xx_hal::{
     adc::{DmaMode, SampleTime, Sequence, ADC},
     delay::DelayCM,
     dma::{dma1, RxDma, Transfer, W},
     prelude::*,
 };
-
-use rtic::app;
 
 const SEQUENCE_LEN: usize = 3;
 
@@ -29,9 +28,7 @@ const APP: () = {
             unsafe { &mut MEMORY }
         };
 
-        rtt_init_print!();
-
-        rprintln!("Hello from init!");
+        println!("Hello from init!");
 
         let cp = cx.core;
         let mut dcb = cp.DCB;
@@ -90,7 +87,7 @@ const APP: () = {
         let transfer = cx.resources.transfer;
         if let Some(transfer_val) = transfer.take() {
             let (buffer, rx_dma) = transfer_val.wait();
-            rprintln!("DMA measurements: {:?}", buffer);
+            println!("DMA measurements: {:?}", buffer);
             *transfer = Some(Transfer::from_adc_dma(
                 rx_dma,
                 buffer,

--- a/examples/adc_dma.rs
+++ b/examples/adc_dma.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use rtic::app;
 use stm32l4xx_hal::{

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
     let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
     // Try a different clock configuration
-    let clocks = rcc.cfgr.hclk(8.MHz()).freeze(&mut flash.acr, &mut pwr);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
     // let clocks = rcc.cfgr
     //     .sysclk(64.MHz())
     //     .pclk1(32.MHz())
@@ -37,8 +37,10 @@ fn main() -> ! {
     loop {
         timer.delay_ms(1000_u32);
         led.set_high();
+        println!("LED on");
         timer.delay_ms(1000_u32);
         led.set_low();
+        println!("LED off");
     }
 }
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -3,16 +3,14 @@
 #![no_main]
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
-// Using RTT for debug + panic handler
-use panic_rtt_target as _; // panic handler
-use rtt_target::{rprintln, rtt_init_print}; // RTT functions
+use defmt::println;
+use panic_probe as _;
 use stm32l4xx_hal as hal; // hal
 use stm32l4xx_hal::{delay::Delay, prelude::*};
 
 #[entry]
 fn main() -> ! {
-    rtt_init_print!();
-    rprintln!("Hello, world!");
+    println!("Hello, world!");
 
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -4,6 +4,7 @@
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal as hal; // hal
 use stm32l4xx_hal::{delay::Delay, prelude::*};

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -9,17 +9,15 @@ use bxcan::{
     filter::Mask32,
     {Frame, StandardId},
 };
-use panic_halt as _;
+use defmt::println;
+use panic_probe as _;
 use rtic::app;
-use rtt_target::{rprintln, rtt_init_print};
 use stm32l4xx_hal::{can::Can, prelude::*};
 
 #[app(device = stm32l4xx_hal::stm32, peripherals = true)]
 const APP: () = {
     #[init]
     fn init(cx: init::Context) {
-        rtt_init_print!();
-
         let dp = cx.device;
 
         let mut flash = dp.FLASH.constrain();
@@ -30,7 +28,7 @@ const APP: () = {
         // Set the clocks to 80 MHz
         let _clocks = rcc.cfgr.sysclk(80.MHz()).freeze(&mut flash.acr, &mut pwr);
 
-        rprintln!("  - CAN init");
+        println!("  - CAN init");
 
         let can = {
             let rx =
@@ -79,12 +77,12 @@ const APP: () = {
         // Wait for TX to finish
         while !can.is_transmitter_idle() {}
 
-        rprintln!("  - CAN tx complete: {:?}", test_frame);
+        println!("  - CAN tx complete: {:?}", test_frame);
 
         // Receive the packet back
         let r = can.receive();
 
-        rprintln!("  - CAN rx {:?}", r);
+        println!("  - CAN rx {:?}", r);
 
         assert_eq!(Ok(test_frame), r);
     }

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -7,6 +7,7 @@ use bxcan::{
     {Frame, StandardId},
 };
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use rtic::app;
 use stm32l4xx_hal::{can::Can, prelude::*};

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -1,7 +1,4 @@
 //! Run the bxCAN peripheral in loopback mode.
-
-#![deny(unsafe_code)]
-#![deny(warnings)]
 #![no_main]
 #![no_std]
 

--- a/examples/i2c_write.rs
+++ b/examples/i2c_write.rs
@@ -4,6 +4,7 @@
 
 use cortex_m_rt as rt;
 use defmt::println;
+use defmt_rtt as _;
 use hal::{
     i2c::{self, I2c},
     prelude::*,

--- a/examples/i2c_write.rs
+++ b/examples/i2c_write.rs
@@ -1,32 +1,19 @@
 //! Blinks an LED
-
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
-#[macro_use]
-extern crate cortex_m_rt as rt;
-extern crate cortex_m_semihosting as sh;
-extern crate panic_semihosting;
-extern crate stm32l4xx_hal as hal;
-
-use crate::hal::prelude::*;
-
-use crate::hal::i2c;
-use crate::hal::i2c::I2c;
-use crate::rt::entry;
-use crate::rt::ExceptionFrame;
-
-use crate::sh::hio;
-use core::fmt::Write;
+use cortex_m_rt as rt;
+use defmt::println;
+use hal::{
+    i2c::{self, I2c},
+    prelude::*,
+};
+use panic_probe as _;
+use rt::{entry, ExceptionFrame};
+use stm32l4xx_hal as hal;
 
 #[entry]
 fn main() -> ! {
-    let mut hstdout = hio::hstdout().unwrap();
-
-    // writeln!(hstdout, "Hello, world!").unwrap();
-
-    // let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
@@ -56,32 +43,31 @@ fn main() -> ! {
         &mut rcc.apb1r1,
     );
 
-    // i2c.write(0x3C, &[0xCC, 0xAA]).unwrap();
     let mut buffer = [0u8; 2];
-    // 0x08 is version reg
-    // i2c.write(0x6C, &[0x08],).unwrap();
-    // let val = i2c.read(0x36, &mut buffer).unwrap();
+
     const MAX17048_ADDR: u8 = 0x6C;
-    i2c.write_read(MAX17048_ADDR, &[0x08], &mut buffer).unwrap();
-    let version: u16 = (buffer[0] as u16) << 8 | buffer[1] as u16;
-    writeln!(hstdout, "Silicon Version: {}", version).ok();
+    // read two bytes starting from version register high byte
+    const MAX17048_VERSION_REG: u8 = 0x08;
+    i2c.write_read(MAX17048_ADDR, &[MAX17048_VERSION_REG], &mut buffer)
+        .unwrap();
+    let version: u16 = u16::from_be_bytes(buffer); // (buffer[0] as u16) << 8 | buffer[1] as u16;
+    println!("Silicon Version: {}", version).ok();
 
     // let soc: u16 = (buffer[0] as u16) + (buffer[1] as u16 / 256);  //& 0xFF00
     // let soc: u16 = (buffer[0] as u16) << 8 & 0xFF00 | (buffer[1] as u16) & 0x00FF;
-    i2c.write_read(MAX17048_ADDR, &[0x04], &mut buffer).unwrap();
-    let soc: u16 = (buffer[0] as u16) << 8 | buffer[1] as u16;
-    writeln!(hstdout, "Batt SoC: {}%", soc / 256).ok();
+    const MAX17048_SOC_REG: u8 = 0x04;
+    i2c.write_read(MAX17048_ADDR, &[MAX17048_SOC_REG], &mut buffer)
+        .unwrap();
+    let soc: u16 = u16::from_be_bytes(buffer);
+    println!("Batt SoC: {}%", soc / 256).ok();
 
-    i2c.write_read(MAX17048_ADDR, &[0x02], &mut buffer).unwrap();
-    let vlt: u16 = (buffer[0] as u16) << 8 | buffer[1] as u16;
-    writeln!(hstdout, "Volt: {}", vlt as f32 * 0.000078125).ok();
+    const MAX17048_VOLT_REG: u8 = 0x02;
+    i2c.write_read(MAX17048_ADDR, &[MAX17048_VOLT_REG], &mut buffer)
+        .unwrap();
+    let vlt: u16 = u16::from_be_bytes(buffer);
+    println!("Volt: {}", vlt as f32 * 0.000078125).ok();
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -8,6 +8,7 @@ use cortex_m::{
 };
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     gpio::{gpioc::PC13, Edge, ExtiPin, Input, PullUp},

--- a/examples/irq_button.rs
+++ b/examples/irq_button.rs
@@ -1,66 +1,57 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
-extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
-extern crate stm32l4xx_hal as hal;
-
-use crate::hal::{
+use core::{cell::RefCell, ops::DerefMut};
+use cortex_m::{
+    interrupt::{free, Mutex},
+    peripheral::NVIC,
+};
+use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
+use stm32l4xx_hal::{
     gpio::{gpioc::PC13, Edge, ExtiPin, Input, PullUp},
     interrupt,
     prelude::*,
     stm32,
 };
-use core::cell::RefCell;
-use core::ops::DerefMut;
-use cortex_m::{
-    interrupt::{free, Mutex},
-    peripheral::NVIC,
-};
-use rt::entry;
 
 // Set up global state. It's all mutexed up for concurrency safety.
 static BUTTON: Mutex<RefCell<Option<PC13<Input<PullUp>>>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
-    if let Some(mut dp) = stm32::Peripherals::take() {
-        dp.RCC.apb2enr.write(|w| w.syscfgen().set_bit());
+    let mut dp = stm32::Peripherals::take().unwrap();
+    dp.RCC.apb2enr.write(|w| w.syscfgen().set_bit());
 
-        let mut rcc = dp.RCC.constrain();
-        let mut flash = dp.FLASH.constrain(); // .constrain();
-        let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
+    let mut rcc = dp.RCC.constrain();
+    let mut flash = dp.FLASH.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
 
-        rcc.cfgr
-            .hclk(48.MHz())
-            .sysclk(80.MHz())
-            .pclk1(24.MHz())
-            .pclk2(24.MHz())
-            .freeze(&mut flash.acr, &mut pwr);
+    rcc.cfgr
+        .hclk(48.MHz())
+        .sysclk(80.MHz())
+        .pclk1(24.MHz())
+        .pclk2(24.MHz())
+        .freeze(&mut flash.acr, &mut pwr);
 
-        // Create a button input with an interrupt
-        let mut gpioc = dp.GPIOC.split(&mut rcc.ahb2);
-        let mut board_btn = gpioc
-            .pc13
-            .into_pull_up_input(&mut gpioc.moder, &mut gpioc.pupdr);
-        board_btn.make_interrupt_source(&mut dp.SYSCFG, &mut rcc.apb2);
-        board_btn.enable_interrupt(&mut dp.EXTI);
-        board_btn.trigger_on_edge(&mut dp.EXTI, Edge::Falling);
+    // Create a button input with an interrupt
+    let mut gpioc = dp.GPIOC.split(&mut rcc.ahb2);
+    let mut board_btn = gpioc
+        .pc13
+        .into_pull_up_input(&mut gpioc.moder, &mut gpioc.pupdr);
+    board_btn.make_interrupt_source(&mut dp.SYSCFG, &mut rcc.apb2);
+    board_btn.enable_interrupt(&mut dp.EXTI);
+    board_btn.trigger_on_edge(&mut dp.EXTI, Edge::Falling);
 
-        // Enable interrupts
-        unsafe {
-            NVIC::unmask(stm32::Interrupt::EXTI15_10);
-        }
-
-        free(|cs| {
-            BUTTON.borrow(cs).replace(Some(board_btn));
-        });
-
-        loop {
-            continue;
-        }
+    // Enable interrupts
+    unsafe {
+        NVIC::unmask(stm32::Interrupt::EXTI15_10);
     }
+
+    free(|cs| {
+        BUTTON.borrow(cs).replace(Some(board_btn));
+    });
 
     loop {
         continue;
@@ -73,6 +64,7 @@ fn EXTI15_10() {
         let mut btn_ref = BUTTON.borrow(cs).borrow_mut();
         if let Some(ref mut btn) = btn_ref.deref_mut() {
             if btn.check_interrupt() {
+                println!("button pressed");
                 // if we don't clear this bit, the ISR would trigger indefinitely
                 btn.clear_interrupt_pending_bit();
             }

--- a/examples/lptim_rtic.rs
+++ b/examples/lptim_rtic.rs
@@ -4,9 +4,9 @@
 #![deny(unsafe_code)]
 #![no_main]
 #![no_std]
-extern crate panic_rtt_target;
 
-use rtt_target::rprintln;
+use defmt::println;
+use panic_probe as _;
 use stm32l4xx_hal::{
     flash::ACR,
     gpio::{gpiob::PB13, Output, PinState, PushPull},
@@ -36,9 +36,7 @@ const APP: () = {
 
     #[init]
     fn init(ctx: init::Context) -> init::LateResources {
-        rtt_target::rtt_init_print!();
-
-        rprintln!("Init start");
+        println!("Init start");
         let device = ctx.device;
         // Configure the clock.
         let mut rcc = device.RCC.constrain();
@@ -53,7 +51,7 @@ const APP: () = {
             &mut gpiob.otyper,
             PinState::Low,
         );
-        rprintln!("Clocks = {:#?}", clocks);
+        println!("Clocks = {:#?}", defmt::Debug2Format(&clocks));
         let lptim_config = LowPowerTimerConfig::default()
             .clock_source(ClockSource::LSE)
             .prescaler(PreScaler::U1)
@@ -74,7 +72,7 @@ const APP: () = {
         let timer_tick::Resources { lptim, led } = ctx.resources;
         if lptim.is_event_triggered(Event::AutoReloadMatch) {
             lptim.clear_event_flag(Event::AutoReloadMatch);
-            rprintln!("LPTIM1 tick");
+            println!("LPTIM1 tick");
 
             led.toggle();
         }

--- a/examples/lptim_rtic.rs
+++ b/examples/lptim_rtic.rs
@@ -6,6 +6,7 @@
 #![no_std]
 
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     flash::ACR,

--- a/examples/otg_fs_serial.rs
+++ b/examples/otg_fs_serial.rs
@@ -6,6 +6,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     gpio::Speed,

--- a/examples/pll_config.rs
+++ b/examples/pll_config.rs
@@ -6,6 +6,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal as hal;
 use stm32l4xx_hal::{

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,10 +1,10 @@
 //! Testing PWM output
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{delay, prelude::*, stm32};
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,14 +1,11 @@
 //! Testing PWM output
-
 #![deny(unsafe_code)]
-#![deny(warnings)]
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
-
-// use cortex_m::asm;
 use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
 use stm32l4xx_hal::{delay, prelude::*, stm32};
 
 #[entry]
@@ -53,24 +50,24 @@ fn main() -> ! {
     // NB: if the pins are LEDs, brightness is not
     //     linear in duty value.
     loop {
+        println!("100%");
         pwm.set_duty(max);
         timer.delay_ms(second);
-        // asm::bkpt();
 
+        println!("91%");
         pwm.set_duty(max / 11 * 10);
         timer.delay_ms(second);
-        // asm::bkpt();
 
+        println!("75%");
         pwm.set_duty(3 * max / 4);
         timer.delay_ms(second);
-        // asm::bkpt();
 
+        println!("50%");
         pwm.set_duty(max / 2);
         timer.delay_ms(second);
-        // asm::bkpt();
 
+        println!("25%");
         pwm.set_duty(max / 4);
         timer.delay_ms(second);
-        // asm::bkpt();
     }
 }

--- a/examples/qspi.rs
+++ b/examples/qspi.rs
@@ -4,21 +4,14 @@
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-// #[macro_use(block)]
-extern crate nb;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::prelude::*;
-use crate::hal::qspi::{Qspi, QspiConfig, QspiMode, QspiReadCommand};
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
+use stm32l4xx_hal as hal;
+use stm32l4xx_hal::{
+    prelude::*,
+    qspi::{Qspi, QspiConfig, QspiMode, QspiReadCommand},
+};
 
 #[entry]
 fn main() -> ! {
@@ -77,15 +70,9 @@ fn main() -> ! {
 
     qspi.transfer(get_id_command, &mut id_arr).unwrap();
 
-    // if all goes well you should reach this breakpoint
-    asm::bkpt();
+    println!("QSPI transfer complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/qspi.rs
+++ b/examples/qspi.rs
@@ -6,6 +6,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal as hal;
 use stm32l4xx_hal::{

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -1,32 +1,16 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-extern crate stm32l4xx_hal as hal;
-
-use core::fmt;
 use cortex_m_rt::entry;
-
-use crate::hal::delay::Delay;
-use crate::hal::prelude::*;
-use crate::hal::serial::{Config, Serial};
-use crate::hal::stm32;
-use hal::hal::blocking::rng::Read;
-
-macro_rules! uprint {
-    ($serial:expr, $($arg:tt)*) => {
-        fmt::write($serial, format_args!($($arg)*)).ok()
-    };
-}
-
-macro_rules! uprintln {
-    ($serial:expr, $fmt:expr) => {
-        uprint!($serial, concat!($fmt, "\n"))
-    };
-    ($serial:expr, $fmt:expr, $($arg:tt)*) => {
-        uprint!($serial, concat!($fmt, "\n"), $($arg)*)
-    };
-}
+use defmt::println;
+use panic_probe as _;
+use stm32l4xx_hal::{
+    delay::Delay,
+    hal::blocking::rng::Read,
+    prelude::*,
+    serial::{Config, Serial},
+    stm32,
+};
 
 #[entry]
 fn main() -> ! {
@@ -69,7 +53,7 @@ fn main() -> ! {
     // setup rng
     let mut rng = device.RNG.enable(&mut rcc.ahb2, clocks);
 
-    uprintln!(&mut tx, "{:?}", clocks);
+    println!("{:?}", defmt::Debug2Format(&clocks));
 
     let some_time: u32 = 500;
     loop {
@@ -77,7 +61,7 @@ fn main() -> ! {
         let mut random_bytes = [0u8; N];
         rng.read(&mut random_bytes)
             .expect("missing random data for some reason");
-        uprintln!(&mut tx, "{} random u8 values: {:?}", N, random_bytes);
+        println!("{} random u8 values: {:?}", N, random_bytes);
 
         timer.delay_ms(some_time);
     }

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -28,25 +28,6 @@ fn main() -> ! {
         .pclk1(32.MHz())
         .freeze(&mut flash.acr, &mut pwr);
 
-    // setup usart
-    let mut gpioa = device.GPIOA.split(&mut rcc.ahb2);
-    let tx = gpioa
-        .pa9
-        .into_alternate(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
-    let rx = gpioa
-        .pa10
-        .into_alternate(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh);
-
-    let baud_rate = 9_600; // 115_200;
-    let serial = Serial::usart1(
-        device.USART1,
-        (tx, rx),
-        Config::default().baudrate(baud_rate.bps()),
-        clocks,
-        &mut rcc.apb2,
-    );
-    let (mut tx, _) = serial.split();
-
     // get a timer
     let mut timer = Delay::new(core.SYST, clocks);
 

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -3,14 +3,9 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
-use stm32l4xx_hal::{
-    delay::Delay,
-    hal::blocking::rng::Read,
-    prelude::*,
-    serial::{Config, Serial},
-    stm32,
-};
+use stm32l4xx_hal::{delay::Delay, hal::blocking::rng::Read, prelude::*, stm32};
 
 #[entry]
 fn main() -> ! {

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -3,30 +3,21 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
-#[macro_use]
-extern crate cortex_m_rt as rt;
-extern crate cortex_m_semihosting as sh;
-extern crate panic_semihosting;
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::datetime::{Date, Time};
-use crate::hal::delay::Delay;
-use crate::hal::prelude::*;
-use crate::hal::rcc::{ClockSecuritySystem, CrystalBypass};
-use crate::hal::rtc::{Rtc, RtcClockSource, RtcConfig};
-use crate::rt::ExceptionFrame;
-
-use crate::sh::hio;
-use core::fmt::Write;
+use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
+use stm32l4xx_hal::{
+    self as hal,
+    datetime::{Date, Time},
+    delay::Delay,
+    prelude::*,
+    rcc::{ClockSecuritySystem, CrystalBypass},
+    rtc::{Rtc, RtcClockSource, RtcConfig},
+};
 
 #[entry]
 fn main() -> ! {
-    let mut hstdout = hio::hstdout().unwrap();
-
-    writeln!(hstdout, "Hello, world!").unwrap();
+    println!("Hello, world!");
 
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();
@@ -62,15 +53,10 @@ fn main() -> ! {
 
     let (rtc_date, rtc_time) = rtc.get_date_time();
 
-    writeln!(hstdout, "Time: {:?}", rtc_time).unwrap();
-    writeln!(hstdout, "Date: {:?}", rtc_date).unwrap();
-    writeln!(hstdout, "Good bye!").unwrap();
+    println!("Time: {:?}", defmt::Debug2Format(&rtc_time));
+    println!("Date: {:?}", defmt::Debug2Format(&rtc_date));
+    println!("Good bye!");
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -5,6 +5,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     self as hal,

--- a/examples/rtc_alarm.rs
+++ b/examples/rtc_alarm.rs
@@ -7,11 +7,12 @@ use core::{cell::RefCell, ops::DerefMut};
 use cortex_m::interrupt::{self, free, Mutex};
 use cortex_m_rt::{entry, exception, interrupt, ExceptionFrame};
 use defmt::println;
-use hal::device::NVIC;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     self as hal,
     datetime::{Date, Time},
+    device::NVIC,
     prelude::*,
     rcc::{ClockSecuritySystem, CrystalBypass},
     rtc::{Event, Rtc, RtcClockSource, RtcConfig},

--- a/examples/rtc_alarm.rs
+++ b/examples/rtc_alarm.rs
@@ -4,8 +4,8 @@
 #![no_main]
 
 use core::{cell::RefCell, ops::DerefMut};
-use cortex_m::interrupt::{self, free, Mutex};
-use cortex_m_rt::{entry, exception, interrupt, ExceptionFrame};
+use cortex_m::interrupt::{free, Mutex};
+use cortex_m_rt::entry;
 use defmt::println;
 use defmt_rtt as _;
 use panic_probe as _;
@@ -13,6 +13,7 @@ use stm32l4xx_hal::{
     self as hal,
     datetime::{Date, Time},
     device::NVIC,
+    interrupt,
     prelude::*,
     rcc::{ClockSecuritySystem, CrystalBypass},
     rtc::{Event, Rtc, RtcClockSource, RtcConfig},
@@ -80,9 +81,4 @@ fn RTC_WKUP() {
             }
         }
     });
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/rtic_frame_serial_dma.rs
+++ b/examples/rtic_frame_serial_dma.rs
@@ -9,6 +9,7 @@
 #![no_std]
 
 use defmt::println;
+use defmt_rtt as _;
 use heapless::{
     pool,
     pool::singleton::{Box, Pool},

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -6,6 +6,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use nb::block;
 use panic_probe as _;
 use stm32l4xx_hal::{self as hal, prelude::*, serial::Serial};

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -1,25 +1,14 @@
 //! Test the serial interface
 //!
 //! This example requires you to short (connect) the TX and RX pins.
-#![deny(warnings)]
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-#[macro_use(block)]
-extern crate nb;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::prelude::*;
-use crate::hal::serial::Serial;
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use nb::block;
+use panic_probe as _;
+use stm32l4xx_hal::{self as hal, prelude::*, serial::Serial};
 
 #[entry]
 fn main() -> ! {
@@ -65,21 +54,13 @@ fn main() -> ! {
     // The `block!` macro makes an operation block until it finishes
     // NOTE the error type is `!`
 
-    block!(tx.write(sent)).ok();
-
+    block!(tx.write(sent)).unwrap();
     let received = block!(rx.read()).unwrap();
 
     assert_eq!(received, sent);
-
-    // if all goes well you should reach this breakpoint
-    asm::bkpt();
+    println!("example complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -7,7 +7,9 @@
 use cortex_m::singleton;
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use nb::block;
+use panic_probe as _;
 use stm32l4xx_hal::{
     self as hal,
     dma::CircReadDma,

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -4,23 +4,16 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(singleton)]
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-#[macro_use(block)]
-extern crate nb;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::dma::CircReadDma;
-use crate::hal::prelude::*;
-use crate::hal::serial::{Config, Serial};
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m::singleton;
+use cortex_m_rt::entry;
+use defmt::println;
+use nb::block;
+use stm32l4xx_hal::{
+    self as hal,
+    dma::CircReadDma,
+    prelude::*,
+    serial::{Config, Serial},
+};
 
 #[entry]
 fn main() -> ! {
@@ -122,8 +115,7 @@ fn main() -> ! {
     assert_eq!(rx_len, 8);
     assert_eq!(&rx_buf[..8], b"abcdefgh");
 
-    // if all goes well you should reach this breakpoint
-    asm::bkpt();
+    println!("example completed");
 
     loop {
         continue;
@@ -132,18 +124,8 @@ fn main() -> ! {
 
 fn send(tx: &mut impl embedded_hal::serial::Write<u8>, data: &[u8]) {
     for byte in data {
-        if let Err(_) = block!(tx.write(*byte)) {
-            panic!("serial tx failed");
+        if let Err(_e) = block!(tx.write(*byte)) {
+            panic!("error occurred while sending bytes");
         }
     }
-
-    // waste some time so that the data will be received completely
-    for _ in 0..10000 {
-        cortex_m::asm::nop();
-    }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/serial_dma_us2.rs
+++ b/examples/serial_dma_us2.rs
@@ -4,10 +4,12 @@
 #![no_main]
 #![no_std]
 
-use cortex_m::{asm, singleton};
-use cortex_m_rt::{entry, exception, ExceptionFrame};
+use cortex_m::singleton;
+use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use nb::block;
+use panic_probe as _;
 use stm32l4xx_hal::{self as hal, dma::CircReadDma, prelude::*, serial::Serial};
 
 #[entry]

--- a/examples/serial_echo_rtic.rs
+++ b/examples/serial_echo_rtic.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 use defmt::println;
+use defmt_rtt as _;
 use heapless::{consts::U8, spsc};
 use nb::block;
 use panic_probe as _;

--- a/examples/serial_half_duplex.rs
+++ b/examples/serial_half_duplex.rs
@@ -3,25 +3,18 @@
 //! This example requires you to hook-up a pullup resistor on the TX pin. RX pin is not used.
 //! Resistor value depends on the baurate and line caracteristics, 1KOhms works well in most cases.
 //! Half-Duplex mode internally connect TX to RX, meaning that bytes sent will also be received.
-#![deny(warnings)]
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-#[macro_use(block)]
-extern crate nb;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::prelude::*;
-use crate::hal::serial::{Config, Serial};
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use nb::block;
+use panic_probe as _;
+use stm32l4xx_hal::{
+    self as hal,
+    prelude::*,
+    serial::{Config, Serial},
+};
 
 #[entry]
 fn main() -> ! {
@@ -64,25 +57,14 @@ fn main() -> ! {
     let (mut tx, mut rx) = serial.split();
 
     let sent = b'X';
-
     // The `block!` macro makes an operation block until it finishes
-    // NOTE the error type is `!`
-
-    block!(tx.write(sent)).ok();
-
+    block!(tx.write(sent)).unwrap();
     let received = block!(rx.read()).unwrap();
 
     assert_eq!(received, sent);
-
-    // if all goes well you should reach this breakpoint
-    asm::bkpt();
+    println!("example complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/serial_half_duplex.rs
+++ b/examples/serial_half_duplex.rs
@@ -8,6 +8,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use nb::block;
 use panic_probe as _;
 use stm32l4xx_hal::{

--- a/examples/serial_hw_flow.rs
+++ b/examples/serial_hw_flow.rs
@@ -6,6 +6,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use nb::block;
 use panic_probe as _;
 use stm32l4xx_hal::{

--- a/examples/serial_hw_flow.rs
+++ b/examples/serial_hw_flow.rs
@@ -1,25 +1,18 @@
 //! Test the serial interface
 //!
 //! This example requires you to short (connect) the TX and RX pins.
-#![deny(warnings)]
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-#[macro_use(block)]
-extern crate nb;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::prelude::*;
-use crate::hal::serial::{Config, Serial};
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use nb::block;
+use panic_probe as _;
+use stm32l4xx_hal::{
+    self as hal,
+    prelude::*,
+    serial::{Config, Serial},
+};
 
 #[entry]
 fn main() -> ! {
@@ -74,25 +67,13 @@ fn main() -> ! {
     let (mut tx, mut rx) = serial.split();
 
     let sent = b'X';
-
-    // The `block!` macro makes an operation block until it finishes
-    // NOTE the error type is `!`
-
-    block!(tx.write(sent)).ok();
-
+    block!(tx.write(sent)).unwrap();
     let received = block!(rx.read()).unwrap();
 
     assert_eq!(received, sent);
-
-    // if all goes well you should reach this breakpoint
-    asm::bkpt();
+    println!("example complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/serial_vcom.rs
+++ b/examples/serial_vcom.rs
@@ -5,6 +5,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use nb::block;
 use panic_probe as _;
 use stm32l4xx_hal::{

--- a/examples/serial_vcom.rs
+++ b/examples/serial_vcom.rs
@@ -3,21 +3,15 @@
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-#[macro_use(block)]
-extern crate nb;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-// #[macro_use(block)]
-// extern crate nb;
-
-use crate::hal::prelude::*;
-use crate::hal::serial::{Config, Serial};
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use nb::block;
+use panic_probe as _;
+use stm32l4xx_hal::{
+    self as hal,
+    prelude::*,
+    serial::{Config, Serial},
+};
 
 #[entry]
 fn main() -> ! {
@@ -62,11 +56,11 @@ fn main() -> ! {
     // The `block!` macro makes an operation block until it finishes
     // NOTE the error type is `!`
 
-    block!(tx.write(sent)).ok();
-    block!(tx.write(sent)).ok();
-    block!(tx.write(sent)).ok();
-    block!(tx.write(sent)).ok();
-    block!(tx.write(sent)).ok();
+    block!(tx.write(sent)).unwrap();
+    block!(tx.write(sent)).unwrap();
+    block!(tx.write(sent)).unwrap();
+    block!(tx.write(sent)).unwrap();
+    block!(tx.write(sent)).unwrap();
 
     // when using virtual com port for recieve can causes a framing error
     // On the stm32l476 discovery it is working fine at 115200 baud
@@ -75,14 +69,9 @@ fn main() -> ! {
     assert_eq!(received, sent);
 
     // if all goes well you should reach this breakpoint
-    asm::bkpt();
+    println!("example complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/spi_dma_rxtx.rs
+++ b/examples/spi_dma_rxtx.rs
@@ -1,10 +1,9 @@
 //! Test the SPI in RX/TX (transfer) DMA mode
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
-use panic_rtt_target as _;
-use rtt_target::rprintln;
+use defmt::println;
+use panic_probe as _;
 use stm32l4xx_hal::{
     dma::TransferDma,
     gpio::{PinState, Speed},
@@ -20,8 +19,7 @@ const APP: () = {
     fn init(cx: init::Context) {
         static mut DMA_BUF: [u8; 5] = [0xf0, 0xaa, 0x00, 0xff, 0x0f];
 
-        rtt_target::rtt_init_print!();
-        rprintln!("Initializing... ");
+        println!("Initializing... ");
 
         let dp = cx.device;
 
@@ -34,7 +32,7 @@ const APP: () = {
         //
         // Initialize the clocks to 80 MHz
         //
-        rprintln!("  - Clock init");
+        println!("  - Clock init");
         let clocks = rcc
             .cfgr
             .msi(MsiFreq::RANGE4M)
@@ -77,7 +75,7 @@ const APP: () = {
         let dma_spi = spi.with_rxtx_dma(dma1_channels.2, dma1_channels.3);
 
         // Check the buffer before using it
-        rprintln!("buf pre: 0x{:x?}", &DMA_BUF);
+        println!("buf pre: 0x{:?}", &DMA_BUF);
 
         // Perform transfer and wait for it to finish (blocking), this can also be done using
         // interrupts on the desired DMA channel
@@ -88,7 +86,7 @@ const APP: () = {
 
         // Inspect the extracted buffer, if the MISO is connected to VCC or GND it will be all 0 or
         // 1.
-        rprintln!("buf post: 0x{:x?}", &buf);
+        println!("buf post: 0x{:?}", &buf);
     }
 
     // Idle function so RTT keeps working

--- a/examples/spi_dma_rxtx.rs
+++ b/examples/spi_dma_rxtx.rs
@@ -3,6 +3,7 @@
 #![no_std]
 
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     dma::TransferDma,

--- a/examples/spi_slave.rs
+++ b/examples/spi_slave.rs
@@ -4,7 +4,9 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use embedded_hal::spi::{Mode, Phase, Polarity};
+use panic_probe as _;
 use stm32l4xx_hal::{self as hal, prelude::*, spi::Spi};
 
 /// SPI mode

--- a/examples/spi_slave.rs
+++ b/examples/spi_slave.rs
@@ -2,18 +2,10 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-extern crate cortex_m;
-extern crate embedded_hal as ehal;
-extern crate panic_semihosting;
-extern crate stm32l4xx_hal as hal;
-
-use crate::ehal::spi::{Mode, Phase, Polarity};
-use crate::hal::prelude::*;
-use crate::hal::spi::Spi;
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use embedded_hal::spi::{Mode, Phase, Polarity};
+use stm32l4xx_hal::{self as hal, prelude::*, spi::Spi};
 
 /// SPI mode
 pub const MODE: Mode = Mode {
@@ -62,14 +54,9 @@ fn main() -> ! {
 
     // when you reach this breakpoint you'll be able to inspect the variable `data` which contains the
     // data sent by the master
-    asm::bkpt();
+    println!("example complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/spi_write.rs
+++ b/examples/spi_write.rs
@@ -4,6 +4,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use embedded_hal::spi::{Mode, Phase, Polarity};
 use panic_probe as _;
 use stm32l4xx_hal::{self as hal, prelude::*, spi::Spi};

--- a/examples/spi_write.rs
+++ b/examples/spi_write.rs
@@ -2,18 +2,11 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-extern crate cortex_m;
-extern crate embedded_hal as ehal;
-extern crate panic_semihosting;
-extern crate stm32l4xx_hal as hal;
-
-use crate::ehal::spi::{Mode, Phase, Polarity};
-use crate::hal::prelude::*;
-use crate::hal::spi::Spi;
-use crate::rt::ExceptionFrame;
-use cortex_m::asm;
+use cortex_m_rt::entry;
+use defmt::println;
+use embedded_hal::spi::{Mode, Phase, Polarity};
+use panic_probe as _;
+use stm32l4xx_hal::{self as hal, prelude::*, spi::Spi};
 
 /// SPI mode
 pub const MODE: Mode = Mode {
@@ -84,14 +77,9 @@ fn main() -> ! {
 
     // when you reach this breakpoint you'll be able to inspect the variable `_m` which contains the
     // gyroscope and the temperature sensor readings
-    asm::bkpt();
+    println!("example complete");
 
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -6,6 +6,7 @@
 use cortex_m::peripheral::NVIC;
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{
     self as hal, interrupt,

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -3,27 +3,19 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
-#[macro_use]
-extern crate cortex_m_rt as rt;
-extern crate cortex_m_semihosting as sh;
-extern crate panic_semihosting;
-extern crate stm32l4xx_hal as hal;
-
-use crate::hal::interrupt;
-use crate::hal::prelude::*;
-use crate::hal::timer::{Event, Timer};
-use crate::rt::entry;
-use crate::rt::ExceptionFrame;
 use cortex_m::peripheral::NVIC;
-
-use crate::sh::hio;
-use core::fmt::Write;
+use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
+use stm32l4xx_hal::{
+    self as hal, interrupt,
+    prelude::*,
+    timer::{Event, Timer},
+};
 
 #[entry]
 fn main() -> ! {
-    let mut hstdout = hio::hstdout().unwrap();
-    writeln!(hstdout, "Hello, world!").unwrap();
+    println!("Hello, world!");
 
     // let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();
@@ -51,11 +43,5 @@ fn main() -> ! {
 fn TIM7() {
     static mut COUNT: u32 = 0;
     *COUNT += 1;
-    // let mut hstdout = hio::hstdout().unwrap();
-    // writeln!(hstdout, "Hello, TIM!").unwrap();
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
+    println!("TIM7 interrupt");
 }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -4,16 +4,9 @@
 #![no_main]
 #![no_std]
 
-extern crate cortex_m;
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
-
-extern crate stm32l4xx_hal as hal;
-
-use crate::hal::prelude::*;
-use crate::hal::tsc::Tsc;
-use crate::rt::ExceptionFrame;
+use cortex_m_rt::entry;
+use panic_probe as _;
+use stm32l4xx_hal::{self as hal, prelude::*, tsc::Tsc};
 
 #[entry]
 fn main() -> ! {
@@ -28,8 +21,6 @@ fn main() -> ! {
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
     let _clocks = rcc.cfgr.freeze(&mut flash.acr, &mut pwr);
-    // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
-    // let clocks = rcc.cfgr.sysclk(64.MHz()).pclk1(32.MHz()).freeze(&mut flash.acr);
 
     // let mut delay = Delay::new(cp.SYST, clocks);
     let mut led = gpiob
@@ -65,9 +56,4 @@ fn main() -> ! {
             led.set_low();
         }
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -5,6 +5,8 @@
 #![no_std]
 
 use cortex_m_rt::entry;
+use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{self as hal, prelude::*, tsc::Tsc};
 
@@ -51,8 +53,10 @@ fn main() -> ! {
         // try and pass c1, it will detect an error!
         let _touched_c2_again = tsc.read(&mut c2).unwrap();
         if touched < threshold {
+            println!("touch channel 1 is below the threshold");
             led.set_high();
         } else {
+            println!("touch channel 1 is above the threshold");
             led.set_low();
         }
     }

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -5,6 +5,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::usb::{Peripheral, UsbBus};
 use stm32l4xx_hal::{prelude::*, stm32};

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -3,9 +3,9 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_semihosting;
-
 use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
 use stm32l4xx_hal::usb::{Peripheral, UsbBus};
 use stm32l4xx_hal::{prelude::*, stm32};
 use usb_device::prelude::*;
@@ -92,6 +92,7 @@ fn main() -> ! {
             Ok(count) if count > 0 => {
                 led.set_high(); // Turn on
 
+                println!("received {}", &buf[0..count]);
                 // Echo back in upper case
                 for c in buf[0..count].iter_mut() {
                     if 0x61 <= *c && *c <= 0x7a {

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -4,6 +4,7 @@
 
 use cortex_m_rt::entry;
 use defmt::println;
+use defmt_rtt as _;
 use panic_probe as _;
 use stm32l4xx_hal::{self as hal, delay::Delay, prelude::*, watchdog::IndependentWatchdog};
 

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -2,22 +2,14 @@
 #![no_std]
 #![no_main]
 
-use crate::hal::delay::Delay;
-use crate::hal::prelude::*;
-use crate::hal::watchdog::IndependentWatchdog;
-use cortex_m_rt::{entry, exception, ExceptionFrame};
-use cortex_m_semihosting as sh;
-use panic_semihosting as _;
-use stm32l4xx_hal as hal;
-
-use crate::sh::hio;
-use core::fmt::Write;
+use cortex_m_rt::entry;
+use defmt::println;
+use panic_probe as _;
+use stm32l4xx_hal::{self as hal, delay::Delay, prelude::*, watchdog::IndependentWatchdog};
 
 #[entry]
 fn main() -> ! {
-    let mut hstdout = hio::hstdout().unwrap();
-
-    writeln!(hstdout, "Hello, world!").unwrap();
+    println!("Hello, world!");
 
     let cp = cortex_m::Peripherals::take().unwrap();
     let dp = hal::stm32::Peripherals::take().unwrap();
@@ -47,13 +39,9 @@ fn main() -> ! {
     timer.delay_ms(1000_u32);
 
     watchdog.feed();
-    writeln!(hstdout, "Good bye!").unwrap();
+    println!("Good bye!");
+    // watchdog will reset after 1020 milliseconds
     loop {
         continue;
     }
-}
-
-#[exception]
-unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
-    panic!("{:#?}", ef);
 }


### PR DESCRIPTION
Uses probe-run / defmt as the runner/logger combo for all examples. I see (after making all the changes...) probe-run now supports rtt-target so if that would be preferred I can update

Additionally, did a bit of clean up on the examples, mostly just merging imports and removing "extern crate" and similar