### PR TITLE
resolve all warnings and clippy lints

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -92,9 +92,9 @@ impl From<u8> for Sequence {
     }
 }
 
-impl Into<u8> for Sequence {
-    fn into(self) -> u8 {
-        match self {
+impl From<Sequence> for u8 {
+    fn from(seq: Sequence) -> u8 {
+        match seq {
             Sequence::One => 0,
             Sequence::Two => 1,
             Sequence::Three => 2,
@@ -592,7 +592,7 @@ impl Default for Resolution {
 }
 
 impl Resolution {
-    fn to_max_count(&self) -> u32 {
+    fn to_max_count(self) -> u32 {
         match self {
             Resolution::Bits12 => (1 << 12) - 1,
             Resolution::Bits10 => (1 << 10) - 1,

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -291,7 +291,7 @@ impl<'a> WriteErase for FlashProgramming<'a> {
 
         let mut chunks = aligned_data.chunks_exact(mem::size_of::<Self::NativeType>());
 
-        while let Some(exact_chunk) = chunks.next() {
+        for exact_chunk in chunks.by_ref() {
             // Write chunks
             let native = &[Self::NativeType::from_ne_bytes(
                 exact_chunk.try_into().unwrap(),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -317,7 +317,7 @@ where
             w.start()
                 .set_bit()
                 .sadd()
-                .bits(u16(addr << 1 | 0))
+                .bits(u16(addr << 1))
                 .add10()
                 .clear_bit()
                 .rd_wrn()
@@ -357,7 +357,7 @@ where
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
         // TODO support transfers of more than 255 bytes
-        assert!(buffer.len() < 256 && buffer.len() > 0);
+        assert!(buffer.len() < 256 && !buffer.is_empty());
 
         // Wait for any previous address sequence to end
         // automatically. This could be up to 50% of a bus
@@ -369,7 +369,7 @@ where
         // is BUSY or I2C is in slave mode.
         self.i2c.cr2.write(|w| {
             w.sadd()
-                .bits((addr << 1 | 0) as u16)
+                .bits((addr << 1) as u16)
                 .rd_wrn()
                 .read()
                 .nbytes()
@@ -402,8 +402,8 @@ where
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
         // TODO support transfers of more than 255 bytes
-        assert!(bytes.len() < 256 && bytes.len() > 0);
-        assert!(buffer.len() < 256 && buffer.len() > 0);
+        assert!(bytes.len() < 256 && !bytes.is_empty());
+        assert!(buffer.len() < 256 && !buffer.is_empty());
 
         // Wait for any previous address sequence to end
         // automatically. This could be up to 50% of a bus
@@ -417,7 +417,7 @@ where
             w.start()
                 .set_bit()
                 .sadd()
-                .bits(u16(addr << 1 | 0))
+                .bits(u16(addr << 1))
                 .add10()
                 .clear_bit()
                 .rd_wrn()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! the STM32L432KC microcontroller. Participation is of course very welcome!
 
 #![no_std]
+#![allow(clippy::upper_case_acronyms)]
 
 #[cfg(not(any(
     feature = "stm32l431",

--- a/src/lptimer.rs
+++ b/src/lptimer.rs
@@ -170,7 +170,7 @@ macro_rules! hal {
                     // This operation is sound, as it is an atomic memory access
                     // that does not modify the memory/read value
                     ClockSource::HSI16 => {
-                        assert!(unsafe { (&*RCC::ptr()).cr.read().hsion().bit_is_set() })
+                        assert!(unsafe { (*RCC::ptr()).cr.read().hsion().bit_is_set() })
                     }
                     _ => {}
                 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -106,7 +106,8 @@ impl RngCore for Rng {
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        Ok(self.fill_bytes(dest))
+        self.fill_bytes(dest);
+        Ok(())
     }
 }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -158,7 +158,19 @@ impl RtcConfig {
 }
 
 impl Rtc {
+    #[allow(clippy::self_named_constructors)]
+    #[deprecated = "use `new()` instead"]
     pub fn rtc(
+        rtc: RTC,
+        apb1r1: &mut APB1R1,
+        bdcr: &mut BDCR,
+        pwrcr1: &mut pwr::CR1,
+        rtc_config: RtcConfig,
+    ) -> Self {
+        Self::new(rtc, apb1r1, bdcr, pwrcr1, rtc_config)
+    }
+
+    pub fn new(
         rtc: RTC,
         apb1r1: &mut APB1R1,
         bdcr: &mut BDCR,
@@ -178,9 +190,6 @@ impl Rtc {
 
     /// Get date and time touple
     pub fn get_date_time(&self) -> (Date, Time) {
-        let time;
-        let date;
-
         let sync_p = self.rtc_config.sync_prescaler as u32;
         let micros =
             1_000_000u32 / (sync_p + 1) * (sync_p - self.rtc.ssr.read().ss().bits() as u32);
@@ -191,7 +200,7 @@ impl Rtc {
         // calendar shadow registers until RTC_DR is read.
         let dater = self.rtc.dr.read();
 
-        time = Time::new(
+        let time = Time::new(
             (bcd2_to_byte((timer.ht().bits(), timer.hu().bits())) as u32).hours(),
             (bcd2_to_byte((timer.mnt().bits(), timer.mnu().bits())) as u32).minutes(),
             (bcd2_to_byte((timer.st().bits(), timer.su().bits())) as u32).secs(),
@@ -199,7 +208,7 @@ impl Rtc {
             cr.bkp().bit(),
         );
 
-        date = Date::new(
+        let date = Date::new(
             dater.wdu().bits().into(),
             bcd2_to_byte((dater.dt().bits(), dater.du().bits())).into(),
             bcd2_to_byte((dater.mt().bit() as u8, dater.mu().bits())).into(),

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -110,7 +110,7 @@ macro_rules! hal {
                     // SSI: set nss high = master mode
                     // CRCEN: hardware CRC calculation disabled
                     // BIDIMODE: 2 line unidirectional (full duplex)
-                    spi.cr1.write(|w| unsafe {
+                    spi.cr1.write(|w|  {
                         w.cpha()
                             .bit(mode.phase == Phase::CaptureOnSecondTransition)
                             .cpol()
@@ -191,7 +191,7 @@ macro_rules! hal {
                 /// Change the baud rate of the SPI
                 pub fn reclock(&mut self, freq: Hertz, clocks: Clocks) {
                     self.spi.cr1.modify(|_, w| w.spe().clear_bit());
-                    self.spi.cr1.modify(|_, w| unsafe {
+                    self.spi.cr1.modify(|_, w| {
                         w.br().bits(Self::compute_baud_rate(clocks.$pclkX(), freq));
                         w.spe().set_bit()
                     });

--- a/src/time.rs
+++ b/src/time.rs
@@ -51,7 +51,7 @@ impl MonoTimer {
     /// Returns an `Instant` corresponding to "now"
     pub fn now(&self) -> Instant {
         Instant {
-            now: DWT::get_cycle_count(),
+            now: DWT::cycle_count(),
         }
     }
 }
@@ -65,6 +65,6 @@ pub struct Instant {
 impl Instant {
     /// Ticks elapsed since the `Instant` was created
     pub fn elapsed(&self) -> u32 {
-        DWT::get_cycle_count().wrapping_sub(self.now)
+        DWT::cycle_count().wrapping_sub(self.now)
     }
 }

--- a/src/tsc.rs
+++ b/src/tsc.rs
@@ -137,7 +137,16 @@ pub enum ChargeDischargeTime {
 }
 
 impl<SPIN> Tsc<SPIN> {
+    #[allow(clippy::self_named_constructors)]
+    #[deprecated = "use `new()` instead"]
     pub fn tsc(tsc: TSC, sample_pin: SPIN, ahb: &mut AHB1, cfg: Option<Config>) -> Self
+    where
+        SPIN: SamplePin<TSC>,
+    {
+        Self::new(tsc, sample_pin, ahb, cfg)
+    }
+
+    pub fn new(tsc: TSC, sample_pin: SPIN, ahb: &mut AHB1, cfg: Option<Config>) -> Self
     where
         SPIN: SamplePin<TSC>,
     {


### PR DESCRIPTION
Any remaining warnings lints should be in `examples/` and resolved by #297 