### PR TITLE
Shorten old buffer when we have extra characters in DMA buffer after a character match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v0.7.0] - 2021-04-04
+
+## [v0.7.1] - 2022-04-11
+
+### Fixed
+
+    - Shorten old buffer when we have extra characters in DMA buffer after a character match.
+## [v0.7.0] - 2022-04-04
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32l4xx-hal"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Scott Mabin <MabezDev@gmail.com>"]
 description = "Hardware abstraction layer for the stm32l4xx chips"
 keywords = ["no-std", "stm32l4xx", "stm32l4", "embedded", "embedded-hal"]

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -848,6 +848,7 @@ macro_rules! dma {
 
                             self.payload.channel.set_memory_address(unsafe { new_buf.buffer_as_ptr().add(diff) } as u32, true);
                             self.payload.channel.set_transfer_length((new_buf.max_len() - diff) as u16);
+                            unsafe { old_buf.set_len(got_data_len - diff) };
                             let received_buffer = core::mem::replace(&mut self.buffer, next_frame);
 
                             // NOTE(compiler_fence) operations on `buffer` should not be reordered after


### PR DESCRIPTION
Shorten old buffer when we have extra characters in DMA buffer after a character match, as to not receive duplicate characters.