### PR TITLE
Add I2C `AddressingMode`.

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -494,7 +494,7 @@ where
             };
 
             w.sadd()
-                .bits(u16(addr << 1 | 1))
+                .bits(addr)
                 .rd_wrn()
                 .read()
                 .nbytes()
@@ -511,6 +511,8 @@ where
 
             *byte = self.i2c.rxdr.read().rxdata().bits();
         }
+
+        // automatic STOP
 
         Ok(())
     }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -374,7 +374,7 @@ where
         busy_wait!(self.i2c, tc, is_complete);
 
         // Stop
-        self.i2c.cr2.modify(|r, w| w.stop().set_bit());
+        self.i2c.cr2.modify(|_, w| w.stop().set_bit());
 
         Ok(())
         // Tx::new(&self.i2c)?.write(addr, bytes)


### PR DESCRIPTION
This doesn't actually do anything useful at the moment since all functions that accept an address are only `u8`, but makes the code a bit more readable.

It took me quite a while to figure out why my code was working with the STM32 C HAL but not in Rust: The C HAL expects the address to already be shifted while this is done internally in the Rust HAL.