### PR TITLE
Enable256 bytes transfer

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -24,7 +24,7 @@ use crate::pac::{i2c1, I2C1, I2C2, I2C3};
 
 use crate::rcc::{Clocks, Enable, RccBus, Reset};
 use crate::time::Hertz;
-use cast::{u16, u8};
+use cast::u8;
 use core::ops::Deref;
 
 /// I2C error


### PR DESCRIPTION
It is now possible to write/read more than 255 bytes in a single transaction.
We tested the read function with more than 255 bytes.
Our Eeprom only supports writing with pages, so we were not able to test if writing more than 255 byte in a single chunk works.
As it is writing with pages less than 255 bytes works.
If someone tests this and it fails, the old write function is commented out so a fall back is easy.