### PR TITLE
Added feature gate to add PA1, PA11, PA12 as SPI1 pins

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -334,13 +334,19 @@ pins!(SPI1, 5,
 pins!(SPI1, 5, SCK: [PG2], MISO: [PG3], MOSI: [PG4]);
 
 #[cfg(any(
-    feature = "stm32l452", 
-    feature = "stm32l462", 
-    feature = "stm32l412", 
+    feature = "stm32l412",
     feature = "stm32l422",
     feature = "stm32l432",
     feature = "stm32l442",
-    
+    feature = "stm32l452",
+    feature = "stm32l462",
+    feature = "stm32l4a6",
+    feature = "stm32l496",
+    feature = "stm32l431",
+    feature = "stm32l451",
+    feature = "stm32l433",
+    feature = "stm32l443",
+    // not supported on stm32l471, stm32l475, stm32l476, stm32l486
 ))]
 pins!(SPI1, 5, SCK: [PA1], MISO: [PA11], MOSI: [PA12]);
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -333,6 +333,17 @@ pins!(SPI1, 5,
 ))]
 pins!(SPI1, 5, SCK: [PG2], MISO: [PG3], MOSI: [PG4]);
 
+#[cfg(any(
+    feature = "stm32l452", 
+    feature = "stm32l462", 
+    feature = "stm32l412", 
+    feature = "stm32l422",
+    feature = "stm32l432",
+    feature = "stm32l442",
+    
+))]
+pins!(SPI1, 5, SCK: [PA1], MISO: [PA11], MOSI: [PA12]);
+
 #[cfg(not(any(feature = "stm32l433", feature = "stm32l443",)))]
 use crate::stm32::SPI3;
 


### PR DESCRIPTION
Added one set of additional SPI1 pins which are present on the stm32l4x2 MCUs.
I quickly poked around if other stm32l4 MCUs have these, but didn't checked all of them in depth.

Tested on the stm32l452.