### PR TITLE
Added missing pins for spi for the stm32l496

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -379,7 +379,7 @@ pins!(SPI2, 5,
 
 #[cfg(any(feature = "stm32l496",))]
 pins!(SPI2, 3,
-    SCK: [PD3],
+    SCK: [PA9, PD3],
     MISO: [],
     MOSI: [PC1]);
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -377,6 +377,12 @@ pins!(SPI2, 5,
     MISO: [PB14, PC2, PD3],
     MOSI: [PB15, PC3, PD4]);
 
+#[cfg(any(feature = "stm32l496",))]
+pins!(SPI2, 3,
+    SCK: [PD3],
+    MISO: [],
+    MOSI: [PC1]);
+
 pub struct SpiPayload<SPI, PINS> {
     spi: Spi<SPI, PINS>,
 }


### PR DESCRIPTION
You can double check me by going to https://www.st.com/resource/en/datasheet/stm32l496ae.pdf pages 98-106