### PR TITLE
Bump `synopsys-usb-otg` to 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.6.0"
 optional = true
 
 [dependencies.synopsys-usb-otg]
-version = "0.2.4"
+version = "0.3.2"
 features = ["cortex-m", "fs"]
 optional = true
 


### PR DESCRIPTION
Bumps `synopsys-usb-otg` from 0.2.4 to 0.3.2 in order to pull in the fix for stm32-rs/synopsys-usb-otg#33. Diff [here](https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.2.4..v0.3.2).

Tested and working on STM32L476. Maintainers, please let me know if more testing is needed and what I can do to help.