### PR TITLE
Use `write` method to update register in the hal macro

### DIFF
--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -675,9 +675,7 @@ impl<CLK, NCS, IO0, IO1, IO2, IO3> Qspi<(CLK, NCS, IO0, IO1, IO2, IO3)> {
         if let Some((data, _)) = command.data {
             for byte in data {
                 while self.qspi.sr.read().ftf().bit_is_clear() {}
-                unsafe {
-                    ptr::write_volatile(&self.qspi.dr as *const _ as *mut u8, *byte);
-                }
+                self.qspi.dr.write(|w| unsafe { w.bits(u32::from(*byte)) });
             }
         }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -520,7 +520,7 @@ macro_rules! hal {
                         // NOTE(unsafe) atomic write to stateless register
                         // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
                         unsafe {
-                            ptr::write_volatile(&(*pac::$USARTX::ptr()).tdr as *const _ as *mut _, byte)
+                            (*pac::$USARTX::ptr()).tdr.write(|w| { w.tdr().bits(u16::from(byte)) });
                         }
                         Ok(())
                     } else {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -268,7 +268,7 @@ macro_rules! hal {
                         nb::Error::Other(Error::Crc)
                     } else if sr.txe().bit_is_set() {
                         // NOTE(write_volatile) see note above
-                        unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte) }
+                        self.spi.dr.write(|w| unsafe{ w.bits(u32::from(byte) ) });
                         return Ok(());
                     } else {
                         nb::Error::WouldBlock


### PR DESCRIPTION
This PR use the `write` method to update register in the `qspi`,`spi` and `usart` HAL since the current updating way will cause compiler error like this (using `nightly-2021-11-15-aarch64-apple-darwin` toolchain)

```
error: assigning to `&T` is undefined behavior, consider using an `UnsafeCell`
   --> eco/stm32l4xx-hal/src/spi.rs:271:34
    |
271 |                           unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte) }
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
371 | / hal! {
372 | |     SPI2: (spi2, spi2_slave, pclk1),
373 | | }
    | |_- in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/book/ch15-05-interior-mutability.html>
    = note: even for types with interior mutability, the only legal way to obtain a mutable pointer from a shared reference is through `UnsafeCell::get`
    = note: this error originates in the macro `hal` (in Nightly builds, run with -Z macro-backtrace for more info)
```

