### PR TITLE
update stm32-usbd to 0.7.0 and tweak the corresponding example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "0.2.6"
 features = ["unproven"]
 
 [dependencies.stm32-usbd]
-version = "0.6.0"
+version = "0.7.0"
 optional = true
 
 [dependencies.synopsys-usb-otg]
@@ -117,8 +117,8 @@ panic-halt = "0.2.0"
 panic-semihosting = "0.5.0"
 cortex-m-semihosting = "0.3.5"
 cortex-m-rt = "0.7"
-usb-device = "0.2.3"
-usbd-serial = "0.1.0"
+usb-device = "0.3.0"
+usbd-serial = "0.2.2"
 heapless = "0.5"
 
 [dev-dependencies.cortex-m-rtic]

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -75,10 +75,12 @@ fn main() -> ! {
     let mut serial = SerialPort::new(&usb_bus);
 
     let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
-        .manufacturer("Fake company")
-        .product("Serial port")
-        .serial_number("TEST")
         .device_class(USB_CLASS_CDC)
+        .strings(&[StringDescriptors::new(0x1234.into())
+            .manufacturer("Fake company")
+            .product("Serial port")
+            .serial_number("TEST")])
+        .unwrap()
         .build();
 
     loop {


### PR DESCRIPTION
This PR upgrade the `stm32-usbd` to `0.7.0`, which indirectly upgrade the `usb-device` to `0.3.0`.

Besides the version bump, this PR also tweak the `usb_serial` example to reflect the latest api changes.