### PR TITLE
fix: Use UnsafeCell after rust 1.73

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _formerly [MabezDev/stm32l4xx-hal](https://github.com/mabezdev/stm32l4xx-hal)_
 
 ## About
 
-    - Minimum rustc version 1.51
+    - Minimum rustc version 1.73
 
 ## License
 

--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -26,7 +26,7 @@ use crate::gpio::{
 use crate::gpio::{Alternate, PushPull, Speed};
 use crate::rcc::{Enable, AHB3};
 use crate::stm32::QUADSPI;
-use core::ptr;
+use core::{cell::UnsafeCell, ptr};
 
 #[doc(hidden)]
 mod private {
@@ -676,7 +676,10 @@ impl<CLK, NCS, IO0, IO1, IO2, IO3> Qspi<(CLK, NCS, IO0, IO1, IO2, IO3)> {
             for byte in data {
                 while self.qspi.sr.read().ftf().bit_is_clear() {}
                 unsafe {
-                    ptr::write_volatile(&self.qspi.dr as *const _ as *mut u8, *byte);
+                    ptr::write_volatile(
+                        UnsafeCell::raw_get(&self.qspi.dr as *const _ as *mut _),
+                        *byte,
+                    );
                 }
             }
         }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -2,6 +2,7 @@
 //!
 //! This module support both polling and interrupt based accesses to the serial peripherals.
 
+use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::DerefMut;
@@ -468,7 +469,7 @@ macro_rules! hal {
                     if isr.rxne().bit_is_set() {
                         // NOTE(read_volatile) see `write_volatile` below
                         return Ok(unsafe {
-                            ptr::read_volatile(&(*pac::$USARTX::ptr()).rdr as *const _ as *const _)
+                            ptr::read_volatile(UnsafeCell::raw_get(&(*pac::$USARTX::ptr()).rdr as *const _ as *const _))
                         });
                     }
 
@@ -520,7 +521,7 @@ macro_rules! hal {
                         // NOTE(unsafe) atomic write to stateless register
                         // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
                         unsafe {
-                            ptr::write_volatile(&(*pac::$USARTX::ptr()).tdr as *const _ as *mut _, byte)
+                            ptr::write_volatile(UnsafeCell::raw_get(&(*pac::$USARTX::ptr()).tdr as *const _ as *mut _), byte)
                         }
                         Ok(())
                     } else {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -5,6 +5,7 @@
 //! don't have it (L432xx and L442xx don't, L452xx does). Users of this MCU variant that
 //! don't have it shouldn't attempt to use it. Relevant info is on user-manual level.
 
+use core::cell::UnsafeCell;
 use core::ptr;
 use core::sync::atomic;
 use core::sync::atomic::Ordering;
@@ -250,7 +251,7 @@ macro_rules! hal {
                         // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
                         // reading a half-word)
                         return Ok(unsafe {
-                            ptr::read_volatile(&self.spi.dr as *const _ as *const u8)
+                            ptr::read_volatile(UnsafeCell::raw_get(&self.spi.dr as *const _ as *const _))
                         });
                     } else {
                         nb::Error::WouldBlock
@@ -268,7 +269,7 @@ macro_rules! hal {
                         nb::Error::Other(Error::Crc)
                     } else if sr.txe().bit_is_set() {
                         // NOTE(write_volatile) see note above
-                        unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte) }
+                        unsafe { ptr::write_volatile(UnsafeCell::raw_get(&self.spi.dr as *const _ as *mut _), byte) }
                         return Ok(());
                     } else {
                         nb::Error::WouldBlock


### PR DESCRIPTION
Fixes discussion in #346 (fails to build in modern Rust versions)

This is a tiny fix which is a cherry-pick of commit c815308ec55b54f1d9b3f72e77629e04a37bae69 from this fork: https://github.com/BillKills974/stm32l4xx-hal 